### PR TITLE
Remove global owner and add aws hard coded

### DIFF
--- a/packaging/rhel/ec2-hibinit-agent.spec
+++ b/packaging/rhel/ec2-hibinit-agent.spec
@@ -4,7 +4,6 @@
 %global moduletype      services
 %global gittag          %{version}-%{release_number}
 %global project         amazon-ec2-hibinit-agent
-%global owner           aws 
 
 %global active_tuned_profile  $(cat %{_sysconfdir}/tuned/active_profile)
  
@@ -20,7 +19,7 @@ Summary:        Hibernation setup utility for Amazon EC2
 
 License:        ASL 2.0
 
-Source0:        https://github.com/%{owner}/%{project}/archive/v%{gittag}/%{name}-%{version}.tar.gz
+Source0:        https://github.com/aws/%{project}/archive/v%{gittag}/%{name}-%{version}.tar.gz
 
 BuildArch:  noarch
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

while installing RPM 
```
Installing ./ec2-hibinit-agent-1.0.3-3.el8.src.rpm
warning: user ec2-user does not exist - using root
warning: group ec2-user does not exist - using root
warning: user ec2-user does not exist - using root
warning: group ec2-user does not exist - using root
```

we shouldn't override directive %{owner}


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
