### PR TITLE
Remove gittag and mark hibinit-config.cfg with config(noreplace)

### DIFF
--- a/packaging/rhel/ec2-hibinit-agent.spec
+++ b/packaging/rhel/ec2-hibinit-agent.spec
@@ -3,7 +3,6 @@
 %global modulenames     ec2hibernatepolicy
 %global selinuxtype     targeted
 %global moduletype      services
-%global gittag          %{version}
 %global project         amazon-ec2-hibinit-agent
 
 %global active_tuned_profile  $(cat %{_sysconfdir}/tuned/active_profile)
@@ -20,7 +19,7 @@ Summary:        Hibernation setup utility for Amazon EC2
 
 License:        ASL 2.0
 
-Source0:        https://github.com/aws/%{project}/archive/v%{gittag}/%{name}-%{version}.tar.gz
+Source0:        https://github.com/aws/%{project}/archive/v%{version}/%{name}-%{version}.tar.gz
 
 BuildArch:  noarch
 
@@ -39,14 +38,14 @@ Requires: tuned
 An EC2 agent that creates a setup for instance hibernation
 
 %prep
-%autosetup -n %{project}-%{gittag}
+%autosetup -n %{project}-%{version}
  
 %build
 %py3_build
 
 # Makefile generates pp.bz2 from .tt file. 
 # Generating tt file https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/selinux_users_and_administrators_guide/security-enhanced_linux-the-sepolicy-suite-sepolicy_generate
-make -C %{_builddir}/%{project}-%{gittag}/packaging/rhel/ec2hibernatepolicy
+make -C %{_builddir}/%{project}-%{version}/packaging/rhel/ec2hibernatepolicy
 
 %install
 %py3_install
@@ -54,28 +53,28 @@ make -C %{_builddir}/%{project}-%{gittag}/packaging/rhel/ec2hibernatepolicy
 mkdir -p %{buildroot}%{python3_sitelib}
 mkdir -p "%{buildroot}%{_unitdir}"
 mkdir -p %{buildroot}%{_sysconfdir}/acpi/events 
-mkdir -p %{buildroot}%{_localstatedir}/lib/hibinit-agent
+mkdir -p %{buildroot}%{_sharedstatedir}/hibinit-agent
 mkdir -p %{buildroot}%{_sysconfdir}/acpi/actions
 
-install -p -m 644 "%{_builddir}/%{project}-%{gittag}/hibinit-agent.service" %{buildroot}%{_unitdir}
-install -p -m 644 "%{_builddir}/%{project}-%{gittag}/acpid.sleep.conf" %{buildroot}%{_sysconfdir}/acpi/events/sleepconf
+install -p -m 644 "%{_builddir}/%{project}-%{version}/hibinit-agent.service" %{buildroot}%{_unitdir}
+install -p -m 644 "%{_builddir}/%{project}-%{version}/acpid.sleep.conf" %{buildroot}%{_sysconfdir}/acpi/events/sleepconf
 
 mkdir -p %{buildroot}%{_prefix}/lib/systemd/logind.conf.d
 mkdir -p %{buildroot}%{_prefix}/lib/systemd/system-sleep
 
-install -p -m 644 "%{_builddir}/%{project}-%{gittag}/etc/hibinit-config.cfg" %{buildroot}/%{_sysconfdir}/hibinit-config.cfg
-install -p -m 644 "%{_builddir}/%{project}-%{gittag}/packaging/rhel/00-hibinit-agent.conf" %{buildroot}%{_prefix}/lib/systemd/logind.conf.d/00-hibinit-agent.conf
-install -p -m 755 "%{_builddir}/%{project}-%{gittag}/packaging/rhel/acpid.sleep.sh" %{buildroot}%{_sysconfdir}/acpi/actions/sleep.sh
-install -p -m 755 "%{_builddir}/%{project}-%{gittag}/packaging/rhel/sleep-handler.sh" %{buildroot}%{_prefix}/lib/systemd/system-sleep/sleep-handler.sh
+install -p -m 644 "%{_builddir}/%{project}-%{version}/etc/hibinit-config.cfg" %{buildroot}/%{_sysconfdir}/hibinit-config.cfg
+install -p -m 644 "%{_builddir}/%{project}-%{version}/packaging/rhel/00-hibinit-agent.conf" %{buildroot}%{_prefix}/lib/systemd/logind.conf.d/00-hibinit-agent.conf
+install -p -m 755 "%{_builddir}/%{project}-%{version}/packaging/rhel/acpid.sleep.sh" %{buildroot}%{_sysconfdir}/acpi/actions/sleep.sh
+install -p -m 755 "%{_builddir}/%{project}-%{version}/packaging/rhel/sleep-handler.sh" %{buildroot}%{_prefix}/lib/systemd/system-sleep/sleep-handler.sh
 
 #Disable transparent huge page
 mkdir -p  %{buildroot}%{_sysconfdir}/tuned/nothp_profile
-install -p -m 644 "%{_builddir}/%{project}-%{gittag}/packaging/rhel/tuned.conf" %{buildroot}%{_sysconfdir}/tuned/nothp_profile/tuned.conf
+install -p -m 644 "%{_builddir}/%{project}-%{version}/packaging/rhel/tuned.conf" %{buildroot}%{_sysconfdir}/tuned/nothp_profile/tuned.conf
 
 # Install policy modules
 %_format MODULES $x.pp.bz2
 install -d %{buildroot}%{_datadir}/selinux/packages
-install -m 0644 %{_builddir}/%{project}-%{gittag}/packaging/rhel/ec2hibernatepolicy/$MODULES \
+install -m 0644 %{_builddir}/%{project}-%{version}/packaging/rhel/ec2hibernatepolicy/$MODULES \
         %{buildroot}%{_datadir}/selinux/packages
 
 
@@ -83,14 +82,14 @@ install -m 0644 %{_builddir}/%{project}-%{gittag}/packaging/rhel/ec2hibernatepol
 %doc README.md
 %license LICENSE.txt
 
-%{_sysconfdir}/hibinit-config.cfg
+%config(noreplace) %{_sysconfdir}/hibinit-config.cfg
 %{_unitdir}/hibinit-agent.service
 %{_bindir}/hibinit-agent
 %config(noreplace) %{_sysconfdir}/acpi/events/sleepconf
 %config(noreplace) %{_sysconfdir}/acpi/actions/sleep.sh
 %{python3_sitelib}/ec2_hibinit_agent-*.egg-info/
-%dir %{_localstatedir}/lib/hibinit-agent
-%ghost %attr(0600,root,root) %{_localstatedir}/lib/hibinit-agent/hibernation-enabled
+%dir %{_sharedstatedir}/hibinit-agent
+%ghost %attr(0600,root,root) %{_sharedstatedir}/hibinit-agent/hibernation-enabled
 
 %dir %{_prefix}/lib/systemd/logind.conf.d
 %dir %{_prefix}/lib/systemd/system-sleep


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

```
> %global gittag          %{version}

This is effectively no longer needed, so you can replace all usage of "%{gittag}" with "%{version}".

> %{_sysconfdir}/hibinit-config.cfg

This needs to be marked as "%config(noreplace)"

> %dir %{_localstatedir}/lib/hibinit-agent
> %ghost %attr(0600,root,root) %{_localstatedir}/lib/hibinit-agent/hibernation-enabled

"%{_localstatedir}/lib" should be replaced with "%{_sharedstatedir}"
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
