### PR TITLE
Fix uninstallation problem in rpm

### DIFF
--- a/packaging/rhel/ec2-hibinit-agent.spec
+++ b/packaging/rhel/ec2-hibinit-agent.spec
@@ -5,8 +5,6 @@
 %global moduletype      services
 %global project         amazon-ec2-hibinit-agent
 
-%global active_tuned_profile  $(cat %{_sysconfdir}/tuned/active_profile)
- 
 # Usage: _format var format
 #   Expand 'modulenames' into various formats as needed
 #   Format must contain '$x' somewhere to do anything useful
@@ -114,23 +112,22 @@ install -m 0644 %{_builddir}/%{project}-%{version}/packaging/rhel/ec2hibernatepo
 %selinux_modules_install -s %{selinuxtype} $MODULES
 
 #
-# Disable THP by switching to  nothp_profile profile
+# Disable THP by switching to nothp_profile profile
 #
-sed -i'' "s/^[#]*\s*include=.*/include=%{active_tuned_profile}/" %{_sysconfdir}/tuned/nothp_profile/tuned.conf
 tuned-adm profile nothp_profile
 
 
 %preun
 %systemd_preun hibinit-agent.service
 
-#
-# Enable THP by switching to nothp_profile profile
-#
-tuned-adm profile $(sed -n 's/^include=//p' %{_sysconfdir}/tuned/nothp_profile/tuned.conf)
-# note that tuned is not enabled and needs to be enabled. 
 
 %postun
 %systemd_postun_with_restart hibinit-agent.service
+
+#
+# Enable THP
+#
+tuned-adm profile virtual-guest
 
 # https://fedoraproject.org/wiki/SELinux/IndependentPolicy
 if [ $1 -eq 0 ]; then

--- a/packaging/rhel/tuned.conf
+++ b/packaging/rhel/tuned.conf
@@ -1,5 +1,5 @@
 [main]
-include=default
+include=virtual-guest
 
 [vm]
 transparent_hugepages=never


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
```
$ sudo rpm --force -e ec2-hibinit-agent-1.0.3-3.fc33
rpm: only installation and upgrading may be forced
[davdunc@ip-172-31-32-29 SPECS]$ sudo rpm -ivh --force ../RPMS/noarch/ec2-hibinit-agent-1.0.3-3.fc33.noarch.rpm 
Verifying...                          ################################# [100%]
Preparing...                          ################################# [100%]
Updating / installing...
   1:ec2-hibinit-agent-1.0.3-3.fc33   ################################# [100%]
Cannot load profile(s) 'nothp_profile': Cannot find profile 'nothp_profile' in '['/etc/tuned', '/usr/lib/tuned']'.
warning: %post(ec2-hibinit-agent-1.0.3-3.fc33.noarch) scriptlet failed, exit status 1
[davdunc@ip-172-31-32-29 SPECS]$ sudo rpm -e ec2-hibinit-agent-1.0.3-3.fc33
Cannot load profile(s) 'nothp_profile': Cannot find profile 'nothp_profile' in '['/etc/tuned', '/usr/lib/tuned']'.
error: %preun(ec2-hibinit-agent-1.0.3-3.fc33.noarch) scriptlet failed, exit status 1
error: ec2-hibinit-agent-1.0.3-3.fc33.noarch: erase failed
```
While building the spec file, it gets the current profile which is nothp_profile. Then use it to return it back to uninstall
if u build spec file in instance that has default profile, it will work. Due to it is a macro, the code executes in build process not in runtime (installation time)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
