### PR TITLE
Remove config no replace for files that do not exist in etc directory

### DIFF
--- a/packaging/rhel/ec2-hibinit-agent.spec
+++ b/packaging/rhel/ec2-hibinit-agent.spec
@@ -95,8 +95,8 @@ install -m 0644 %{_builddir}/%{project}-%{version}/packaging/rhel/ec2hibernatepo
 %dir %{_sysconfdir}/tuned/nothp_profile
 %config(noreplace) %{_sysconfdir}/tuned/nothp_profile/tuned.conf
 
-%config(noreplace) %{_prefix}/lib/systemd/system-sleep/sleep-handler.sh
-%config(noreplace) %{_prefix}/lib/systemd/logind.conf.d/00-hibinit-agent.conf
+%{_prefix}/lib/systemd/system-sleep/sleep-handler.sh
+%{_prefix}/lib/systemd/logind.conf.d/00-hibinit-agent.conf
 %attr(0644,root,root) %{_datadir}/selinux/packages/*.pp.bz2
 
 %pre


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

```
 %config(noreplace) %{_prefix}/lib/systemd/system-sleep/sleep-handler.sh
> %config(noreplace) %{_prefix}/lib/systemd/logind.conf.d/00-hibinit-agent.conf

These *must not* be marked as config files, as %config markers are only allowed for files in /etc.

```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
