### PR TITLE
mkconfig for grub2 to be updated for grubby

### DIFF
--- a/agent/hibinit-agent
+++ b/agent/hibinit-agent
@@ -124,6 +124,9 @@ def patch_grub_config(swap_device, offset):
         return
     fsfreeze = "sync && mountpoint -q {mount} && trap '' HUP INT QUIT TERM && fsfreeze -f {mount} && fsfreeze -u {mount}"
     fsfreeze = fsfreeze.format(mount=mount_point)
+    mkconfig = "grub2-mkconfig -o {path}"
+    mkconfig = mkconfig.format(path="/boot/grub2/grub.cfg")
+    check_output(mkconfig, shell=True)
     check_call(cmd, shell=True)
     check_call(fsfreeze, shell=True)
     log("GRUB configuration is updated")

--- a/packaging/rhel/ec2-hibinit-agent.spec
+++ b/packaging/rhel/ec2-hibinit-agent.spec
@@ -140,7 +140,7 @@ fi
 
 %changelog
 * Thu Jan 14 2021 Mohamed Aboubakr <mabouba@amazon.com> - 1.0.4-1
-- Call gurb2-mkconfig in hibernate agent before calling grubby
+- Call grub2-mkconfig in hibernate agent before calling grubby
 
 * Tue Nov 03 2020 Mohamed Aboubakr <mabouba@amazon.com> - 1.0.3-3
 - Moving selinux folder in packaging directory.

--- a/packaging/rhel/ec2-hibinit-agent.spec
+++ b/packaging/rhel/ec2-hibinit-agent.spec
@@ -140,7 +140,7 @@ fi
 
 %changelog
 * Thu Jan 14 2021 Mohamed Aboubakr <mabouba@amazon.com> - 1.0.4-1
-- Call gurb-mkconfig in hibernate agent before calling grubby
+- Call gurb2-mkconfig in hibernate agent before calling grubby
 
 * Tue Nov 03 2020 Mohamed Aboubakr <mabouba@amazon.com> - 1.0.3-3
 - Moving selinux folder in packaging directory.

--- a/packaging/rhel/ec2-hibinit-agent.spec
+++ b/packaging/rhel/ec2-hibinit-agent.spec
@@ -11,8 +11,8 @@
 %global _format() export %1=""; for x in %{modulenames}; do %1+=%2; %1+=" "; done;
 
 Name:           ec2-hibinit-agent
-Version:        1.0.3
-Release:        3%{?dist}
+Version:        1.0.4
+Release:        1%{?dist}
 Summary:        Hibernation setup utility for Amazon EC2
 
 License:        ASL 2.0
@@ -139,6 +139,9 @@ fi
 %selinux_relabel_post -s %{selinuxtype}
 
 %changelog
+* Thu Jan 14 2021 Mohamed Aboubakr <mabouba@amazon.com> - 1.0.4-1
+- Call gurb-mkconfig in hibernate agent before calling grubby
+
 * Tue Nov 03 2020 Mohamed Aboubakr <mabouba@amazon.com> - 1.0.3-3
 - Moving selinux folder in packaging directory.
 - Use make file to generate .pp.bz2 file


### PR DESCRIPTION
**Problem**
ec2-hibinit agent doesn't work in open suse operating system and hibernate fails due to failure in systemd-sleep process 

```
  26.489789] PM: Using 3 thread(s) for compression.
               PM: Compressing and saving image data (168005 pages)...
[   26.489811] PM: Image saving progress:   0%
[   26.637256] PM: Image saving progress:  10%
[   26.702875] PM: Image saving progress:  20%
[   26.794866] PM: Image saving progress:  30%
[   26.881008] PM: Image saving progress:  40%
[   26.967017] PM: Image saving progress:  50%
[   27.063591] PM: Image saving progress:  60%
[   27.157465] PM: Image saving progress:  70%
[   27.234620] PM: Image saving progress:  80%
[   27.290830] PM: Image saving progress:  90%
[   27.357455] PM: Image saving progress: 100%
[   27.512105] PM: Image saving done.
[   27.512114] PM: Wrote 672020 kbytes in 1.02 seconds (658.84 MB/s)
[   27.512503] PM: S
[   27.514563] PM: Swap header not found!
[   27.514568] |
```

### Cause 
Kernal parameter doesn't have the mandatory parameters that are needed for hibernate process. `resume_offset=XXXX resume=/dev/nvme0n1p3`
`cat /proc/cmdline`
```
BOOT_IMAGE=/boot/vmlinuz-5.3.18-24.37-default root=UUID=15991bdf-394d-4e90-b988-5061b112debe console=ttyS0 net.ifnames=0 nvme_core.io_timeout=4294967295 nvme_core.admin_timeout=4294967295 8250.nr_uarts=4 dis_ucode_ldr multipath=off
```

### Root cause 
Amazon hibinit agent is using `grubby` to update kernel parameter 
https://github.com/aws/amazon-ec2-hibinit-agent/blob/master/agent/hibinit-agent#L119

If you looked at the code, you would see `"grubby --update-kernel=ALL` which update in `ALL` registered kernel in `grubby`.

If you tried to get grubby info for all, you will find no Linux entry. 
```
ec2-user@ip-172-31-65-53:~/rpmbuild/RPMS/noarch> sudo grubby --info=ALL
index=0
non linux entry
index=1
non linux entry
index=2
non linux entry
index=3
non linux entry
index=4
non linux entry
index=5
non linux entry
index=6
non linux entry
ec2-user@ip-172-31-65-53:~/rpmbuild/RPMS/noarch> 
```
But if you did the same `sudo grubby --info=ALL` in **Red hat** you will see
```
index=0
kernel="/boot/vmlinuz-4.18.0-240.1.1.el8_3.x86_64"
args="ro console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto $tuned_params"
root="UUID=949779ce-46aa-434e-8eb0-852514a5d69e"
initrd="/boot/initramfs-4.18.0-240.1.1.el8_3.x86_64.img $tuned_initrd"
title="Red Hat Enterprise Linux (4.18.0-240.1.1.el8_3.x86_64) 8.3 (Ootpa)"
id="d8aff414dbe6429cbe36b52011441ef4-4.18.0-240.1.1.el8_3.x86_64"
index=1
kernel="/vmlinuz-0-rescue-d8aff414dbe6429cbe36b52011441ef4"
args="ro console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 crashkernel=auto"
root="UUID=949779ce-46aa-434e-8eb0-852514a5d69e"
initrd="/initramfs-0-rescue-d8aff414dbe6429cbe36b52011441ef4.img"
title="Red Hat Enterprise Linux (0-rescue-d8aff414dbe6429cbe36b52011441ef4) 8.3 (Ootpa)"
id="d8aff414dbe6429cbe36b52011441ef4-0-rescue"

```


### Solution

Execute `sudo grub2-mkconfig -o /boot/grub2/grub.cfg` before updating the grub in ec2-hibinit agent
```
sudo grubby --default-kernel
/boot/vmlinuz-5.3.18-24.37-default
```

```
sudo grub2-mkconfig -o /boot/grub2/grub.cfg
Generating grub configuration file ...
Found linux image: /boot/vmlinuz-5.3.18-24.37-default
Found initrd image: /boot/initrd-5.3.18-24.37-default
done
ec2-user@ip-172-31-75-38:~/rpmbuild/RPMS/noarch> sudo grubby --info=ALL
index=0
kernel=/boot/vmlinuz-5.3.18-24.37-default
args="console=ttyS0 net.ifnames=0 nvme_core.io_timeout=4294967295 nvme_core.admin_timeout=4294967295 8250.nr_uarts=4 dis_ucode_ldr multipath=off"
root=UUID=15991bdf-394d-4e90-b988-5061b112debe
initrd=/boot/initrd-5.3.18-24.37-default
title=SLES15-SP2
index=1
non linux entry
index=2
kernel=/boot/vmlinuz-5.3.18-24.37-default
args="console=ttyS0 net.ifnames=0 nvme_core.io_timeout=4294967295 nvme_core.admin_timeout=4294967295 8250.nr_uarts=4 dis_ucode_ldr multipath=off"
root=UUID=15991bdf-394d-4e90-b988-5061b112debe
initrd=/boot/initrd-5.3.18-24.37-default
title=SLES15-SP2, with Linux 5.3.18-24.37-default
index=3
kernel=/boot/vmlinuz-5.3.18-24.37-default
args=""
root=UUID=15991bdf-394d-4e90-b988-5061b112debe
initrd=/boot/initrd-5.3.18-24.37-default
title=SLES15-SP2, with Linux 5.3.18-24.37-default (recovery mode)
index=4
non linux entry
index=5
non linux entry
index=6
non linux entry

```

**Test**
Red Hat for backward compatability :- 

```

Jan 21 19:18:16 ip-172-31-66-233 systemd[1]: Reached target Cloud-init target.
Jan 21 19:18:16 ip-172-31-66-233 hibinit-agent[982]: Generating grub configuration file ...
Jan 21 19:18:18 ip-172-31-66-233 kdumpctl[853]: kexec: loaded kdump kernel
Jan 21 19:18:18 ip-172-31-66-233 kdumpctl[853]: Starting kdump: [OK]
Jan 21 19:18:18 ip-172-31-66-233 systemd[1]: Started Crash recovery kernel arming.
Jan 21 19:18:18 ip-172-31-66-233 systemd[1]: Startup finished in 1.486s (kernel) + 5.139s (initrd) + 12.347s (userspace) = 18.973s.
Jan 21 19:18:18 ip-172-31-66-233 kernel: fuse: init (API version 7.31)
Jan 21 19:18:18 ip-172-31-66-233 systemd[1]: Mounting FUSE Control File System...
Jan 21 19:18:18 ip-172-31-66-233 systemd[1]: Mounted FUSE Control File System.
Jan 21 19:18:18 ip-172-31-66-233 root[1548]: os-prober: debug: running /usr/libexec/os-probes/50mounted-tests on /dev/nvme0n1p1
Jan 21 19:18:18 ip-172-31-66-233 root[1548]: 50mounted-tests: debug: /dev/nvme0n1p1 type not recognised; skipping
Jan 21 19:18:18 ip-172-31-66-233 hibinit-agent[982]: done
Jan 21 19:18:18 ip-172-31-66-233 /hibinit-agent[999]: GRUB configuration is updated
Jan 21 19:18:18 ip-172-31-66-233 /hibinit-agent[999]: Setting swap device to 66306 with offset 142810
Jan 21 19:18:18 ip-172-31-66-233 /hibinit-agent[999]: Done updating the swap offset. Turning swapoff
Jan 21 19:18:18 ip-172-31-66-233 /hibinit-agent[999]: Running: swapoff /swap
Jan 21 19:18:18 ip-172-31-66-233 systemd[1]: swap.swap: Succeeded.
Jan 21 19:18:18 ip-172-31-66-233 systemd[986]: swap.swap: Succeeded.
Jan 21 19:18:18 ip-172-31-66-233 systemd[1]: hibinit-agent.service: Succeeded.
````

