### PR TITLE
Calling dracut after creating swapfile to  include systemd-hibernate-resume in initrd

### DIFF
--- a/agent/hibinit-agent
+++ b/agent/hibinit-agent
@@ -160,7 +160,7 @@ def update_kernel_swap_offset(swapon, swapoff, filename, grub_update):
     swapoff = swapoff.format(swapfile=filename)
     log("Running: %s" % swapoff)
     check_call(swapoff, shell=True)
-
+    check_call("dracut -a resume -f", shell=True)
 
 def find_device_for_file(filename):
     # Find the mount point for the swap file ('df -P /swap')


### PR DESCRIPTION
Calling dracut after creating swapfile to  include systemd-hibernate-resume in initrd

**Description of changes:**
When dracut is on 'hostonly' mode (SLE/openSUSE use this mode). The resume module only be installed when dracut detected 'swap' filesystem. No matter the 'resume=' kernel parameter be set or not.

**Testing** 
I tested in Red hat 8.4 and Amazon-linux-2. The change is working fine in both operating systems with 3 full cycles of hibernate-resume. Also, After restarting the guest operating system, the change is still working for further hibernate resume.

**Redhat output :-** 

```
Apr  8 23:00:22 ip-172-31-78-144 systemd[1]: swap.swap: Succeeded.
Apr  8 23:00:22 ip-172-31-78-144 dracut[1470]: dracut-049-95.git20200804.el8_3.4
Apr  8 23:00:22 ip-172-31-78-144 dracut[1472]: Executing: /usr/bin/dracut -a resume -f
Apr  8 23:00:22 ip-172-31-78-144 dracut[1472]: dracut module 'modsign' will not be installed, because command 'keyctl' could not be found!
Apr  8 23:00:22 ip-172-31-78-144 dracut[1472]: dracut module 'busybox' will not be installed, because command 'busybox' could not be found!
Apr  8 23:00:23 ip-172-31-78-144 dracut[1472]: dracut module 'lvmmerge' will not be installed, because command 'lvm' could not be found!
Apr  8 23:00:23 ip-172-31-78-144 dracut[1472]: dracut module 'btrfs' will not be installed, because command 'btrfs' could not be found!
Apr  8 23:00:23 ip-172-31-78-144 dracut[1472]: dracut module 'dmraid' will not be installed, because command 'dmraid' could not be found!
Apr  8 23:00:23 ip-172-31-78-144 dracut[1472]: dracut module 'lvm' will not be installed, because command 'lvm' could not be found!
Apr  8 23:00:23 ip-172-31-78-144 dracut[1472]: dracut module 'mdraid' will not be installed, because command 'mdadm' could not be found!
Apr  8 23:00:23 ip-172-31-78-144 dracut[1472]: dracut module 'multipath' will not be installed, because command 'multipath' could not be found!
Apr  8 23:00:23 ip-172-31-78-144 dracut[1472]: dracut module 'stratis' will not be installed, because command 'stratisd-init' could not be found!
Apr  8 23:00:23 ip-172-31-78-144 dracut[1472]: dracut module 'stratis' will not be installed, because command 'thin_check' could not be found!
Apr  8 23:00:23 ip-172-31-78-144 dracut[1472]: dracut module 'stratis' will not be installed, because command 'thin_repair' could not be found!
Apr  8 23:00:23 ip-172-31-78-144 dracut[1472]: dracut module 'cifs' will not be installed, because command 'mount.cifs' could not be found!
Apr  8 23:00:23 ip-172-31-78-144 dracut[1472]: dracut module 'fcoe' will not be installed, because command 'dcbtool' could not be found!
Apr  8 23:00:23 ip-172-31-78-144 dracut[1472]: dracut module 'fcoe' will not be installed, because command 'fipvlan' could not be found!
Apr  8 23:00:23 ip-172-31-78-144 dracut[1472]: dracut module 'fcoe' will not be installed, because command 'lldpad' could not be found!
Apr  8 23:00:23 ip-172-31-78-144 dracut[1472]: dracut module 'fcoe' will not be installed, because command 'fcoemon' could not be found!
Apr  8 23:00:23 ip-172-31-78-144 dracut[1472]: dracut module 'fcoe' will not be installed, because command 'fcoeadm' could not be found!
Apr  8 23:00:23 ip-172-31-78-144 dracut[1472]: dracut module 'fcoe-uefi' will not be installed, because command 'dcbtool' could not be found!
Apr  8 23:00:23 ip-172-31-78-144 dracut[1472]: dracut module 'fcoe-uefi' will not be installed, because command 'fipvlan' could not be found!
Apr  8 23:00:23 ip-172-31-78-144 dracut[1472]: dracut module 'fcoe-uefi' will not be installed, because command 'lldpad' could not be found!
Apr  8 23:00:23 ip-172-31-78-144 dracut[1472]: dracut module 'iscsi' will not be installed, because command 'iscsi-iname' could not be found!
Apr  8 23:00:23 ip-172-31-78-144 dracut[1472]: dracut module 'iscsi' will not be installed, because command 'iscsiadm' could not be found!
Apr  8 23:00:23 ip-172-31-78-144 dracut[1472]: dracut module 'iscsi' will not be installed, because command 'iscsid' could not be found!
Apr  8 23:00:23 ip-172-31-78-144 dracut[1472]: dracut module 'nbd' will not be installed, because command 'nbd-client' could not be found!
Apr  8 23:00:23 ip-172-31-78-144 kdumpctl[852]: kexec: loaded kdump kernel
Apr  8 23:00:23 ip-172-31-78-144 kdumpctl[852]: Starting kdump: [OK]
Apr  8 23:00:23 ip-172-31-78-144 dracut[1472]: 95nfs: Could not find any command of 'rpcbind portmap'!
Apr  8 23:00:23 ip-172-31-78-144 systemd[1]: Started Crash recovery kernel arming.
Apr  8 23:00:23 ip-172-31-78-144 systemd[1]: Startup finished in 1.664s (kernel) + 4.474s (initrd) + 11.288s (userspace) = 17.428s.
Apr  8 23:00:23 ip-172-31-78-144 chronyd[685]: Selected source 67.135.0.43
Apr  8 23:00:23 ip-172-31-78-144 chronyd[685]: System clock TAI offset set to 37 seconds
Apr  8 23:00:23 ip-172-31-78-144 dracut[1472]: dracut module 'biosdevname' will not be installed, because command 'biosdevname' could not be found!
Apr  8 23:00:23 ip-172-31-78-144 dracut[1472]: memstrack is available
Apr  8 23:00:23 ip-172-31-78-144 dracut[1472]: *** Including module: bash ***
Apr  8 23:00:23 ip-172-31-78-144 dracut[1472]: *** Including module: systemd ***
Apr  8 23:00:23 ip-172-31-78-144 hibinit-agent[989]: Failed to add dependency on unit, unit systemd-ask-password-plymouth.service does not exist.
Apr  8 23:00:23 ip-172-31-78-144 dracut[1472]: *** Including module: systemd-initrd ***
Apr  8 23:00:23 ip-172-31-78-144 dracut[1472]: *** Including module: rngd ***
Apr  8 23:00:23 ip-172-31-78-144 dracut[1472]: *** Including module: i18n ***
Apr  8 23:00:24 ip-172-31-78-144 dracut[1472]: *** Including module: network-manager ***
Apr  8 23:00:24 ip-172-31-78-144 dracut[1472]: *** Including module: network ***
Apr  8 23:00:24 ip-172-31-78-144 dracut[1472]: *** Including module: ifcfg ***
Apr  8 23:00:24 ip-172-31-78-144 dracut[1472]: *** Including module: prefixdevname ***
Apr  8 23:00:24 ip-172-31-78-144 dracut[1472]: *** Including module: crypt ***
Apr  8 23:00:24 ip-172-31-78-144 chronyd[685]: Selected source 169.254.169.123
Apr  8 23:00:24 ip-172-31-78-144 dracut[1472]: *** Including module: dm ***
Apr  8 23:00:24 ip-172-31-78-144 dracut[1472]: Skipping udev rule: 64-device-mapper.rules
Apr  8 23:00:24 ip-172-31-78-144 dracut[1472]: Skipping udev rule: 60-persistent-storage-dm.rules
Apr  8 23:00:24 ip-172-31-78-144 dracut[1472]: Skipping udev rule: 55-dm.rules
Apr  8 23:00:24 ip-172-31-78-144 dracut[1472]: *** Including module: kernel-modules ***
Apr  8 23:00:28 ip-172-31-78-144 dracut[1472]: *** Including module: kernel-modules-extra ***
Apr  8 23:00:28 ip-172-31-78-144 dracut[1472]: *** Including module: kernel-network-modules ***
Apr  8 23:00:28 ip-172-31-78-144 systemd[1]: NetworkManager-dispatcher.service: Succeeded.
Apr  8 23:00:29 ip-172-31-78-144 dracut[1472]: *** Including module: qemu ***
Apr  8 23:00:29 ip-172-31-78-144 dracut[1472]: *** Including module: qemu-net ***
Apr  8 23:00:29 ip-172-31-78-144 dracut[1472]: *** Including module: lunmask ***
Apr  8 23:00:29 ip-172-31-78-144 dracut[1472]: *** Including module: resume ***
Apr  8 23:00:29 ip-172-31-78-144 dracut[1472]: *** Including module: rootfs-block ***
Apr  8 23:00:29 ip-172-31-78-144 dracut[1472]: *** Including module: terminfo ***
Apr  8 23:00:29 ip-172-31-78-144 dracut[1472]: *** Including module: udev-rules ***
Apr  8 23:00:29 ip-172-31-78-144 dracut[1472]: Skipping udev rule: 91-permissions.rules
Apr  8 23:00:29 ip-172-31-78-144 dracut[1472]: Skipping udev rule: 80-drivers-modprobe.rules
Apr  8 23:00:29 ip-172-31-78-144 dracut[1472]: *** Including module: dracut-systemd ***
Apr  8 23:00:29 ip-172-31-78-144 dracut[1472]: *** Including module: usrmount ***
Apr  8 23:00:29 ip-172-31-78-144 dracut[1472]: *** Including module: base ***
Apr  8 23:00:29 ip-172-31-78-144 dracut[1472]: *** Including module: fs-lib ***
Apr  8 23:00:29 ip-172-31-78-144 dracut[1472]: *** Including module: memstrack ***
Apr  8 23:00:29 ip-172-31-78-144 dracut[1472]: *** Including module: microcode_ctl-fw_dir_override ***
Apr  8 23:00:29 ip-172-31-78-144 dracut[1472]:  microcode_ctl module: mangling fw_dir
Apr  8 23:00:29 ip-172-31-78-144 dracut[1472]:    microcode_ctl: reset fw_dir to "/lib/firmware/updates /lib/firmware"
Apr  8 23:00:29 ip-172-31-78-144 dracut[1472]:    microcode_ctl: processing data directory  "/usr/share/microcode_ctl/ucode_with_caveats/intel"...
Apr  8 23:00:29 ip-172-31-78-144 dracut[1472]:      microcode_ctl: intel: caveats check for kernel version "4.18.0-240.22.1.el8_3.x86_64" passed, adding "/usr/share/microcode_ctl/ucode_with_caveats/intel" to fw_dir variable
Apr  8 23:00:29 ip-172-31-78-144 dracut[1472]:    microcode_ctl: processing data directory  "/usr/share/microcode_ctl/ucode_with_caveats/intel-06-2d-07"...
Apr  8 23:00:29 ip-172-31-78-144 dracut[1472]:      microcode_ctl: intel-06-2d-07: caveats check for kernel version "4.18.0-240.22.1.el8_3.x86_64" passed, adding "/usr/share/microcode_ctl/ucode_with_caveats/intel-06-2d-07" to fw_dir variable
Apr  8 23:00:29 ip-172-31-78-144 dracut[1472]:    microcode_ctl: processing data directory  "/usr/share/microcode_ctl/ucode_with_caveats/intel-06-4e-03"...
Apr  8 23:00:29 ip-172-31-78-144 dracut[1472]:    microcode_ctl: kernel version "4.18.0-240.22.1.el8_3.x86_64" failed early load check for "intel-06-4e-03", skipping
Apr  8 23:00:29 ip-172-31-78-144 dracut[1472]:    microcode_ctl: processing data directory  "/usr/share/microcode_ctl/ucode_with_caveats/intel-06-4f-01"...
Apr  8 23:00:29 ip-172-31-78-144 dracut[1472]:    microcode_ctl: kernel version "4.18.0-240.22.1.el8_3.x86_64" failed early load check for "intel-06-4f-01", skipping
Apr  8 23:00:29 ip-172-31-78-144 dracut[1472]:    microcode_ctl: processing data directory  "/usr/share/microcode_ctl/ucode_with_caveats/intel-06-55-04"...
Apr  8 23:00:29 ip-172-31-78-144 dracut[1472]:      microcode_ctl: intel-06-55-04: caveats check for kernel version "4.18.0-240.22.1.el8_3.x86_64" passed, adding "/usr/share/microcode_ctl/ucode_with_caveats/intel-06-55-04" to fw_dir variable
Apr  8 23:00:29 ip-172-31-78-144 dracut[1472]:    microcode_ctl: processing data directory  "/usr/share/microcode_ctl/ucode_with_caveats/intel-06-5e-03"...
Apr  8 23:00:29 ip-172-31-78-144 dracut[1472]:    microcode_ctl: kernel version "4.18.0-240.22.1.el8_3.x86_64" failed early load check for "intel-06-5e-03", skipping
Apr  8 23:00:29 ip-172-31-78-144 dracut[1472]:    microcode_ctl: processing data directory  "/usr/share/microcode_ctl/ucode_with_caveats/intel-06-8c-01"...
Apr  8 23:00:29 ip-172-31-78-144 dracut[1472]:    microcode_ctl: kernel version "4.18.0-240.22.1.el8_3.x86_64" failed early load check for "intel-06-8c-01", skipping
Apr  8 23:00:29 ip-172-31-78-144 dracut[1472]:    microcode_ctl: processing data directory  "/usr/share/microcode_ctl/ucode_with_caveats/intel-06-8e-9e-0x-0xca"...
Apr  8 23:00:29 ip-172-31-78-144 dracut[1472]:    microcode_ctl: kernel version "4.18.0-240.22.1.el8_3.x86_64" failed early load check for "intel-06-8e-9e-0x-0xca", skipping
Apr  8 23:00:29 ip-172-31-78-144 dracut[1472]:    microcode_ctl: processing data directory  "/usr/share/microcode_ctl/ucode_with_caveats/intel-06-8e-9e-0x-dell"...
Apr  8 23:00:29 ip-172-31-78-144 dracut[1472]:      microcode_ctl: intel-06-8e-9e-0x-dell: caveats check for kernel version "4.18.0-240.22.1.el8_3.x86_64" passed, adding "/usr/share/microcode_ctl/ucode_with_caveats/intel-06-8e-9e-0x-dell" to fw_dir variable
Apr  8 23:00:29 ip-172-31-78-144 dracut[1472]:    microcode_ctl: final fw_dir: "/usr/share/microcode_ctl/ucode_with_caveats/intel-06-8e-9e-0x-dell /usr/share/microcode_ctl/ucode_with_caveats/intel-06-55-04 /usr/share/microcode_ctl/ucode_with_caveats/intel-06-2d-07 /usr/share/microcode_ctl/ucode_with_caveats/intel /lib/firmware/updates /lib/firmware"
Apr  8 23:00:29 ip-172-31-78-144 dracut[1472]: *** Including module: shutdown ***
Apr  8 23:00:29 ip-172-31-78-144 dracut[1472]: *** Including modules done ***
Apr  8 23:00:29 ip-172-31-78-144 dracut[1472]: *** Installing kernel module dependencies ***
Apr  8 23:00:31 ip-172-31-78-144 dracut[1472]: *** Installing kernel module dependencies done ***
Apr  8 23:00:31 ip-172-31-78-144 dracut[1472]: *** Resolving executable dependencies ***
Apr  8 23:00:31 ip-172-31-78-144 dracut[1472]: *** Resolving executable dependencies done***
Apr  8 23:00:31 ip-172-31-78-144 dracut[1472]: *** Hardlinking files ***
Apr  8 23:00:32 ip-172-31-78-144 dracut[1472]: *** Hardlinking files done ***
Apr  8 23:00:32 ip-172-31-78-144 dracut[1472]: Could not find 'strip'. Not stripping the initramfs.
Apr  8 23:00:32 ip-172-31-78-144 dracut[1472]: *** Generating early-microcode cpio image ***
Apr  8 23:00:32 ip-172-31-78-144 dracut[1472]: *** Constructing AuthenticAMD.bin ****
Apr  8 23:00:32 ip-172-31-78-144 dracut[1472]: *** Constructing GenuineIntel.bin ****
Apr  8 23:00:32 ip-172-31-78-144 dracut[1472]: *** Constructing GenuineIntel.bin ****
Apr  8 23:00:32 ip-172-31-78-144 dracut[1472]: *** Constructing GenuineIntel.bin ****
Apr  8 23:00:32 ip-172-31-78-144 dracut[1472]: *** Constructing GenuineIntel.bin ****
Apr  8 23:00:32 ip-172-31-78-144 dracut[1472]: *** Store current command line parameters ***
Apr  8 23:00:32 ip-172-31-78-144 dracut[1472]: *** Creating image file '/boot/initramfs-4.18.0-240.22.1.el8_3.x86_64.img' ***
Apr  8 23:00:47 ip-172-31-78-144 systemd[1]: systemd-hostnamed.service: Succeeded.
```

**For Amazon-linux-2** 

```
pr  9 00:38:57 ip-172-31-64-119 dracut: dracut-033-535.amzn2.1.3
Apr  9 00:38:57 ip-172-31-64-119 dracut: Executing: /usr/sbin/dracut -a resume -f
Apr  9 00:38:57 ip-172-31-64-119 dracut: dracut module 'busybox' will not be installed, because command 'busybox' could not be found!
Apr  9 00:38:57 ip-172-31-64-119 dracut: dracut module 'i18n' will not be installed, because it's in the list to be omitted!
Apr  9 00:38:57 ip-172-31-64-119 dracut: dracut module 'plymouth' will not be installed, because it's in the list to be omitted!
Apr  9 00:38:57 ip-172-31-64-119 dracut: dracut module 'btrfs' will not be installed, because command 'btrfs' could not be found!
Apr  9 00:38:57 ip-172-31-64-119 dracut: dracut module 'crypt' will not be installed, because it's in the list to be omitted!
Apr  9 00:38:57 ip-172-31-64-119 dracut: dracut module 'dm' will not be installed, because it's in the list to be omitted!
Apr  9 00:38:57 ip-172-31-64-119 dracut: dracut module 'dmraid' will not be installed, because it's in the list to be omitted!
Apr  9 00:38:57 ip-172-31-64-119 dracut: dracut module 'dmsquash-live-ntfs' will not be installed, because command 'ntfs-3g' could not be found!
Apr  9 00:38:57 ip-172-31-64-119 dracut: dracut module 'lvm' will not be installed, because it's in the list to be omitted!
Apr  9 00:38:57 ip-172-31-64-119 dracut: dracut module 'mdraid' will not be installed, because it's in the list to be omitted!
Apr  9 00:38:57 ip-172-31-64-119 dracut: dracut module 'multipath' will not be installed, because command 'multipath' could not be found!
Apr  9 00:38:57 ip-172-31-64-119 dracut: dracut module 'qemu' will not be installed, because it's in the list to be omitted!
Apr  9 00:38:57 ip-172-31-64-119 dracut: dracut module 'terminfo' will not be installed, because it's in the list to be omitted!
Apr  9 00:38:57 ip-172-31-64-119 dracut: dracut module 'biosdevname' will not be installed, because command 'biosdevname' could not be found!
Apr  9 00:38:57 ip-172-31-64-119 dracut: dracut module 'busybox' will not be installed, because command 'busybox' could not be found!
Apr  9 00:38:57 ip-172-31-64-119 dracut: dracut module 'btrfs' will not be installed, because command 'btrfs' could not be found!
Apr  9 00:38:57 ip-172-31-64-119 dracut: dracut module 'dmsquash-live-ntfs' will not be installed, because command 'ntfs-3g' could not be found!
Apr  9 00:38:57 ip-172-31-64-119 dracut: dracut module 'multipath' will not be installed, because command 'multipath' could not be found!
Apr  9 00:38:57 ip-172-31-64-119 dracut: *** Including module: bash ***
Apr  9 00:38:57 ip-172-31-64-119 dracut: *** Including module: modsign ***
Apr  9 00:38:57 ip-172-31-64-119 dracut: *** Including module: nss-softokn ***
Apr  9 00:38:57 ip-172-31-64-119 dracut: *** Including module: bcache ***
Apr  9 00:38:57 ip-172-31-64-119 dracut: Skipping udev rule: 61-bcache.rules
Apr  9 00:38:57 ip-172-31-64-119 dracut: Skipping udev rule: 69-bcache.rules
Apr  9 00:38:57 ip-172-31-64-119 dracut: *** Including module: kernel-modules ***
Apr  9 00:38:58 ip-172-31-64-119 amazon-ssm-agent: 2021-04-09 00:38:58 INFO [amazon-ssm-agent] [SelfUpdate] Initializing self update ...
Apr  9 00:38:58 ip-172-31-64-119 amazon-ssm-agent: 2021-04-09 00:38:58 INFO [amazon-ssm-agent] Starting Core Agent: amazon-ssm-agent - v3.0.161.0
Apr  9 00:38:58 ip-172-31-64-119 amazon-ssm-agent: 2021-04-09 00:38:58 INFO [amazon-ssm-agent] OS: linux, Arch: amd64
Apr  9 00:38:58 ip-172-31-64-119 dhclient[2136]: XMT: Solicit on eth0, interval 4520ms.
Apr  9 00:38:59 ip-172-31-64-119 dracut: *** Including module: resume ***
Apr  9 00:38:59 ip-172-31-64-119 dracut: *** Including module: rootfs-block ***
Apr  9 00:38:59 ip-172-31-64-119 dracut: *** Including module: udev-rules ***
Apr  9 00:38:59 ip-172-31-64-119 dracut: Skipping udev rule: 40-redhat-cpu-hotplug.rules
Apr  9 00:38:59 ip-172-31-64-119 chronyd[1814]: Selected source 169.254.169.123
Apr  9 00:38:59 ip-172-31-64-119 dracut: Skipping udev rule: 91-permissions.rules
Apr  9 00:38:59 ip-172-31-64-119 dracut: *** Including module: systemd ***
Apr  9 00:38:59 ip-172-31-64-119 dracut: *** Including module: usrmount ***
Apr  9 00:38:59 ip-172-31-64-119 dracut: *** Including module: base ***
Apr  9 00:39:00 ip-172-31-64-119 dracut: *** Including module: fs-lib ***
Apr  9 00:39:00 ip-172-31-64-119 dracut: *** Including module: microcode_ctl-fw_dir_override ***
Apr  9 00:39:00 ip-172-31-64-119 dracut:  microcode_ctl module: mangling fw_dir
Apr  9 00:39:00 ip-172-31-64-119 dracut:    microcode_ctl: processing data directory  "/usr/share/microcode_ctl/ucode_with_caveats/intel"...
Apr  9 00:39:00 ip-172-31-64-119 dracut:      microcode_ctl: intel: caveats check for kernel version "4.14.225-169.362.amzn2.x86_64" passed, adding "/usr/share/microcode_ctl/ucode_with_caveats/intel" to fw_dir variable
Apr  9 00:39:00 ip-172-31-64-119 dracut:    microcode_ctl: processing data directory  "/usr/share/microcode_ctl/ucode_with_caveats/intel-06-4f-01"...
Apr  9 00:39:00 ip-172-31-64-119 dracut:      microcode_ctl: intel-06-4f-01: caveats check for kernel version "4.14.225-169.362.amzn2.x86_64" passed, adding "/usr/share/microcode_ctl/ucode_with_caveats/intel-06-4f-01" to fw_dir variable
Apr  9 00:39:00 ip-172-31-64-119 dracut:    microcode_ctl: final fw_dir: "/usr/share/microcode_ctl/ucode_with_caveats/intel-06-4f-01 /usr/share/microcode_ctl/ucode_with_caveats/intel /lib/firmware/updates /lib/firmware"
Apr  9 00:39:00 ip-172-31-64-119 dracut: *** Including module: shutdown ***
Apr  9 00:39:00 ip-172-31-64-119 dracut: *** Including modules done ***
Apr  9 00:39:00 ip-172-31-64-119 amazon-ssm-agent: 2021-04-09 00:39:00 INFO [amazon-ssm-agent] [LongRunningWorkerContainer] [WorkerProvider] Worker ssm-agent-worker is not running, starting worker process
Apr  9 00:39:00 ip-172-31-64-119 amazon-ssm-agent: 2021-04-09 00:39:00 INFO [amazon-ssm-agent] [LongRunningWorkerContainer] [WorkerProvider] Worker ssm-agent-worker (pid:3990) started
Apr  9 00:39:00 ip-172-31-64-119 amazon-ssm-agent: 2021-04-09 00:39:00 INFO [amazon-ssm-agent] [LongRunningWorkerContainer] Monitor long running worker health every 60 seconds
Apr  9 00:39:00 ip-172-31-64-119 dracut: *** Installing kernel module dependencies and firmware ***
Apr  9 00:39:00 ip-172-31-64-119 dracut: *** Installing kernel module dependencies and firmware done ***
Apr  9 00:39:00 ip-172-31-64-119 dracut: *** Resolving executable dependencies ***
Apr  9 00:39:01 ip-172-31-64-119 systemd: Started Dynamically Generate Message Of The Day.
Apr  9 00:39:01 ip-172-31-64-119 systemd: Reached target Multi-User System.
Apr  9 00:39:01 ip-172-31-64-119 systemd: Starting Multi-User System.
Apr  9 00:39:01 ip-172-31-64-119 systemd: Reached target Graphical Interface.
Apr  9 00:39:01 ip-172-31-64-119 systemd: Starting Graphical Interface.
Apr  9 00:39:01 ip-172-31-64-119 systemd: Reached target Cloud-init target.
Apr  9 00:39:01 ip-172-31-64-119 systemd: Starting Cloud-init target.
Apr  9 00:39:01 ip-172-31-64-119 systemd: Starting Update UTMP about System Runlevel Changes...
Apr  9 00:39:01 ip-172-31-64-119 systemd: Started Update UTMP about System Runlevel Changes.
Apr  9 00:39:01 ip-172-31-64-119 dracut: *** Resolving executable dependencies done***
Apr  9 00:39:01 ip-172-31-64-119 dracut: *** Hardlinking files ***
Apr  9 00:39:01 ip-172-31-64-119 dracut: *** Hardlinking files done ***
Apr  9 00:39:01 ip-172-31-64-119 dracut: *** Stripping files ***
Apr  9 00:39:01 ip-172-31-64-119 dracut: *** Stripping files done ***
Apr  9 00:39:01 ip-172-31-64-119 dracut: *** Generating early-microcode cpio image contents ***
Apr  9 00:39:01 ip-172-31-64-119 dracut: *** Constructing GenuineIntel.bin ****
Apr  9 00:39:01 ip-172-31-64-119 dracut: *** Constructing GenuineIntel.bin ****
Apr  9 00:39:01 ip-172-31-64-119 dracut: *** Constructing GenuineIntel.bin ****
Apr  9 00:39:01 ip-172-31-64-119 dracut: *** Store current command line parameters ***
Apr  9 00:39:01 ip-172-31-64-119 dracut: *** Creating image file ***
Apr  9 00:39:01 ip-172-31-64-119 dracut: *** Creating microcode section ***
Apr  9 00:39:01 ip-172-31-64-119 dracut: *** Created microcode section ***
Apr  9 00:39:03 ip-172-31-64-119 dhclient[2136]: XMT: Solicit on eth0, interval 8880ms.
Apr  9 00:39:03 ip-172-31-64-119 dracut: *** Creating image file done ***
Apr  9 00:39:03 ip-172-31-64-119 systemd: Created slice User Slice of ec2-user.
Apr  9 00:39:03 ip-172-31-64-119 systemd: Starting User Slice of ec2-user.
Apr  9 00:39:03 ip-172-31-64-119 systemd: Started Session 1 of user ec2-user.
Apr  9 00:39:03 ip-172-31-64-119 systemd-logind: New session 1 of user ec2-user.
Apr  9 00:39:03 ip-172-31-64-119 systemd: Starting Session 1 of user ec2-user.
Apr  9 00:39:05 ip-172-31-64-119 dracut: *** Creating initramfs image file '/boot/initramfs-4.14.225-169.362.amzn2.x86_64.img' done ***
Apr  9 00:39:05 ip-172-31-64-119 systemd: Stopping ACPI Event Daemon...
Apr  9 00:39:05 ip-172-31-64-119 acpid: exiting
Apr  9 00:39:05 ip-172-31-64-119 systemd: Starting ACPI Event Daemon...
Apr  9 00:39:05 ip-172-31-64-119 acpid: starting up with netlink and the input layer
Apr  9 00:39:05 ip-172-31-64-119 acpid: skipping incomplete file /etc/acpi/events/videoconf
Apr  9 00:39:05 ip-172-31-64-119 acpid: 2 rules loaded
Apr  9 00:39:05 ip-172-31-64-119 acpid: waiting for events: event logging is off
Apr  9 00:39:05 ip-172-31-64-119 systemd: Started ACPI Event Daemon.
Apr  9 00:39:05 ip-172-31-64-119 systemd: Started Initial hibernation setup job.



```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
