### PR TITLE
Change encoding to use the system locale instead of ascii.

### DIFF
--- a/agent/hibinit-agent
+++ b/agent/hibinit-agent
@@ -164,7 +164,7 @@ def update_kernel_swap_offset(swapon, swapoff, filename, grub_update):
 
 def find_device_for_file(filename):
     # Find the mount point for the swap file ('df -P /swap')
-    df_out = check_output(['df', '-P', filename]).decode('ascii')
+    df_out = check_output(['df', '-P', filename]).decode(sys.getfilesystemencoding())
     dev_str = df_out.split("\n")[1].split()[0]
     return dev_str
 


### PR DESCRIPTION
Issue #, if available:
Ascii encoding may cause issues on systems that use a locale other than C.
Exception "Failed to find the filesystem type of /" occurs in Japanese locale.

Description of changes:
Changed to decode the result of check_output() using the system locale instead of ascii.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
