### PR TITLE
echo swapfile and offset in /sys/power after grub configuration update

### DIFF
--- a/agent/hibinit-agent
+++ b/agent/hibinit-agent
@@ -133,13 +133,13 @@ def patch_grub_config(swap_device, offset):
     # Some of grubby versions need a restart after changing in kernel parameters
     # echo offset and swap device helps the customer to use the agent immediately
     # after rpm installation. 
-    echoResumeDevice = "echo {swap_device} > /sys/power/resume"
-    echoResumeDevice = echoResumeDevice.format(swap_device=swap_device)
-    echoResumeOffset = "echo {offset} > /sys/power/resume_offset"
-    echoResumeOffset = echoResumeOffset.format(offset=offset)
+    echoResumeDeviceCmd = "echo {swap_device} > /sys/power/resume"
+    echoResumeDeviceCmd = echoResumeDeviceCmd.format(swap_device=swap_device)
+    echoResumeOffsetCmd = "echo {offset} > /sys/power/resume_offset"
+    echoResumeOffsetCmd = echoResumeOffsetCmd.format(offset=offset)
 
-    check_output(echoResumeDevice, shell=True)
-    check_output(echoResumeOffset, shell=True)
+    check_output(echoResumeDeviceCmd, shell=True)
+    check_output(echoResumeOffsetCmd, shell=True)
     log("GRUB configuration is updated")
 
 

--- a/agent/hibinit-agent
+++ b/agent/hibinit-agent
@@ -129,6 +129,17 @@ def patch_grub_config(swap_device, offset):
     check_output(mkconfig, shell=True)
     check_call(cmd, shell=True)
     check_call(fsfreeze, shell=True)
+
+    # Some of grubby versions need a restart after changing in kernel parameters
+    # echo offset and swap device helps the customer to use the agent immediately
+    # after rpm installation. 
+    echoResumeDevice = "echo {swap_device} > /sys/power/resume"
+    echoResumeDevice = echoResumeDevice.format(swap_device=swap_device)
+    echoResumeOffset = "echo {offset} > /sys/power/resume_offset"
+    echoResumeOffset = echoResumeOffset.format(offset=offset)
+
+    check_output(echoResumeDevice, shell=True)
+    check_output(echoResumeOffset, shell=True)
     log("GRUB configuration is updated")
 
 


### PR DESCRIPTION
Not all grubby versions doesn't need a restart after updating in kernel parameters. In SUSE disto, the grubby needs a restart after updating in kernel parameters. By this change, the customer can use the rpm immediately after installation

**Testing**
Tested the change in Amazon Linux 2, RHEL8 and SUSE Enterprise Linux 

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
