### PR TITLE
Swapon with maximum priority before hibernation

### DIFF
--- a/acpid.sleep.sh
+++ b/acpid.sleep.sh
@@ -2,9 +2,15 @@
 
 PATH=/sbin:/bin:/usr/bin
 failed='false'
+
+# Hibernation selects the swapfile with highest priority. Since there may be
+# other swapfiles configured, ensure /swap is selected as hibernation
+# target by setting to maximum priority.
+swap_priority=32767
+
 hibernate()
 {
-        swapon /swap && /usr/sbin/pm-hibernate
+        swapon --priority=$swap_priority /swap && /usr/sbin/pm-hibernate
         if [ $? -ne 0 ]
         then
             logger "Hibernation failed, Sleeping 2 mins before retry"


### PR DESCRIPTION
Issue #, if available: #20

Downstream bug in Ubuntu: [LP#1968805](https://bugs.launchpad.net/ubuntu/+source/ec2-hibinit-agent/+bug/1968805)

Description of changes:

With recent versions of systemd, if your system has an additional or multiple swapfiles configured, then swapon adds a swapfile to the system with the next lowest priority.

For example:

```
$ sudo swapon /swap-hibinit
$ swapon --show
NAME TYPE SIZE USED PRIO
/swap-hibinit file 3.9G 0B -2

Turning it off:
$ sudo swapoff /swap-hibinit
$ swapon --show
NAME TYPE SIZE USED PRIO

Lets add /swapfile in:

$ sudo swapon /swapfile
$ swapon --show
NAME TYPE SIZE USED PRIO
/swapfile file 4G 0B -2

Now we enable /swap-hibinit again, and see it is -3:

$ sudo swapon /swap-hibinit
$ swapon --show
NAME TYPE SIZE USED PRIO
/swapfile file 4G 0B -2
/swap-hibinit file 3.9G 0B -3

Lets add in another swapfile, /swapfile-second, and we see -2, -3, -4:

$ sudo swapon /swapfile-second
$ swapon --show
NAME TYPE SIZE USED PRIO
/swapfile file 4G 0B -2
/swap-hibinit file 3.9G 0B -3
/swapfile-second file 4G 0B -4
```

The issue with this is, the system will hibernate to the swapfile with the highest priority. In this case, /swapfile is -2, the highest of any of the swapfiles.

Hibernation will fail, due to only /swap-hibinit being correctly set up on the kernel command line with resume=<UUID> and resume_offset=<offset>. The result is that the EC2 console says "Stopping" for 20 minutes, and then force stops the instance at the 20 minute timeout.

Testcase and more information on the [downstream bug on launchpad](https://bugs.launchpad.net/ubuntu/+source/ec2-hibinit-agent/+bug/1968805).

Fix this by ensuring we swapon the hibinit swapfile with the highest priority, 32767, which will be higher than any manually created swapfiles.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
