### PR TITLE
Add initial Amazon Linux 2022 support

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include README.md LICENSE.txt
 include acpid.sleep.conf
 include acpid.sleep.sh
 include hibinit-agent.service
+include acpid-override.conf

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 sources:
-	python2.7 setup.py sdist --formats=gztar
+	python3 setup.py sdist --formats=gztar
 	mv dist/*.gz .
 	rm -rf dist
 

--- a/acpid-override.conf
+++ b/acpid-override.conf
@@ -1,0 +1,6 @@
+# This file is installed by the amazon-ec2-hibinit-agent package. It
+# ensures that acpid handles ACPI sleep button events instead of
+# systemd-logind.
+[Service]
+ExecStart=
+ExecStart=/usr/bin/systemd-inhibit --what=handle-suspend-key:handle-hibernate-key --who=noah --why="acpid instead" --mode=block /usr/sbin/acpid -f

--- a/ec2-hibinit-agent.spec
+++ b/ec2-hibinit-agent.spec
@@ -7,7 +7,7 @@ Group:          System Environment/Daemons
 License:         Apache 2.0
 Source0:        ec2-hibinit-agent-%{version}.tar.gz
 BuildArch:      noarch
-BuildRequires:  python2 python2-devel systemd acpid
+BuildRequires:  python3-devel systemd-rpm-macros
 %{?systemd_requires}
 
 Requires: acpid grubby
@@ -18,10 +18,10 @@ An EC2 agent that creates a setup for instance hibernation
 %setup -q -n ec2-hibinit-agent-%{version}
 
 %build
-%{__python2} setup.py build
+%{python3} setup.py build
 
 %install
-%{__python2} setup.py install --prefix=usr -O1 --skip-build --root $RPM_BUILD_ROOT
+%{python3} setup.py install --prefix=usr -O1 --skip-build --root $RPM_BUILD_ROOT
 mkdir -p "%{buildroot}%{_unitdir}"
 mkdir -p %{buildroot}%{_sysconfdir}/acpi/events 
 mkdir -p %{buildroot}%{_sysconfdir}/acpi/actions
@@ -36,16 +36,16 @@ install -m0644 "%{_builddir}/%{name}-%{version}/acpid-override.conf" "%{buildroo
 %files
 %defattr(-,root,root)
 %doc README.md
-%{_sysconfdir}/hibinit-config.cfg
-%{_unitdir}/hibinit-agent.service
-%{_unitdir}/acpid.service.d/acpid-override.conf
+/etc/hibinit-config.cfg
+/usr/lib/systemd/system/hibinit-agent.service
+/usr/lib/systemd/system/acpid.service.d/acpid-override.conf
 %{_bindir}/hibinit-agent
 %dir %{_sysconfdir}/acpi
 %dir %{_sysconfdir}/acpi/events
 %dir %{_sysconfdir}/acpi/actions
 %config(noreplace) %attr(0644,root,root) %{_sysconfdir}/acpi/events/sleepconf
 %config(noreplace) %attr(0755,root,root) %{_sysconfdir}/acpi/actions/sleep.sh
-%{python2_sitelib}/*
+%{python3_sitelib}/*
 %dir %{_localstatedir}/lib/hibinit-agent
 %ghost %attr(0600,root,root) %{_localstatedir}/lib/hibinit-agent/hibernation-enabled
 

--- a/ec2-hibinit-agent.spec
+++ b/ec2-hibinit-agent.spec
@@ -30,11 +30,15 @@ install -p -m 644 "%{_builddir}/%{name}-%{version}/hibinit-agent.service" %{buil
 install -p -m 644 "%{_builddir}/%{name}-%{version}/acpid.sleep.conf" %{buildroot}%{_sysconfdir}/acpi/events/sleepconf
 install -p -m 755 "%{_builddir}/%{name}-%{version}/acpid.sleep.sh" %{buildroot}%{_sysconfdir}/acpi/actions/sleep.sh
 
+mkdir -p mkdir -p "%{buildroot}%{_unitdir}/acpid.service.d"
+install -m0644 "%{_builddir}/%{name}-%{version}/acpid-override.conf" "%{buildroot}%{_unitdir}/acpid.service.d"
+
 %files
 %defattr(-,root,root)
 %doc README.md
 %{_sysconfdir}/hibinit-config.cfg
 %{_unitdir}/hibinit-agent.service
+%{_unitdir}/acpid.service.d/acpid-override.conf
 %{_bindir}/hibinit-agent
 %dir %{_sysconfdir}/acpi
 %dir %{_sysconfdir}/acpi/events

--- a/hibinit-agent.service
+++ b/hibinit-agent.service
@@ -15,11 +15,11 @@
 Description=Initial hibernation setup job
 DefaultDependencies=no
 After=cloud-config.service
+Wants=acpid.service
 
 [Service]
 Type=forking
 ExecStart=/usr/bin/hibinit-agent -c /etc/hibinit-config.cfg
-ExecStartPost= /bin/systemctl restart acpid.service
 TimeoutSec=0
 
 # Output needs to appear in instance console output


### PR DESCRIPTION
Issue #, if available: n/a

Description of changes:

Add initial support for Amazon Linux 2022. It's possible that there remain some rough edges, but this works in my testing.

The major functional change is that we invoke acpid with a systemd inhibitor to ensure that it handles the button press events instead of having systemd-logind handle them. This lets us invoke our `sleep.sh` script in response to this event.  See [the systemd documentation](https://www.freedesktop.org/wiki/Software/systemd/inhibit/) and [systemd-inhibit(8) manpage](https://manpages.debian.org/bullseye/systemd/systemd-inhibit.1.en.html) for more information about this works.

I also cleaned up and slightly modernized the .spec file. **Note** AL2022 uses python3, and I updated the .spec file to reflect this. However, I did **not** verify that all of the code is python3 compatible.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
