### PR TITLE
Add `pm-utils` for required package

### DIFF
--- a/ec2-hibinit-agent.spec
+++ b/ec2-hibinit-agent.spec
@@ -10,7 +10,7 @@ BuildArch:      noarch
 BuildRequires:  python2 python2-devel systemd acpid
 %{?systemd_requires}
 
-Requires: acpid grubby
+Requires: acpid grubby pm-utils
 %description
 An EC2 agent that creates a setup for instance hibernation
 


### PR DESCRIPTION
Issue #26 

Description of changes:
Add `pm-utils` as required package for Amazon Linux 2's rpm.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
