### PR TITLE
Recreating the swap file if the current size is sufficiently larger 

### DIFF
--- a/agent/hibinit-agent
+++ b/agent/hibinit-agent
@@ -41,6 +41,7 @@ HIB_ENABLED_FILE = "hibernation-enabled"
 IMDS_BASEURL = 'http://169.254.169.254'
 IMDS_API_TOKEN_PATH = 'latest/api/token'
 IMDS_SPOT_ACTION_PATH = 'latest/meta-data/hibernation/configured'
+MAX_SWAP_SIZE_OFFSET_ALLOWED = 100 * 1024 
 
 def log(message):
     if log_to_syslog:
@@ -467,7 +468,11 @@ def main():
         cur_swap = os.path.getsize(SWAP_FILE)
 
     bi = None
-    if cur_swap >= target_swap_size - SWAP_RESERVED_SIZE:
+    if cur_swap > target_swap_size - SWAP_RESERVED_SIZE + MAX_SWAP_SIZE_OFFSET_ALLOWED:
+        log("Swap already exists! (have %d, need %d), deleting existing swap file %s since current swap is sufficiently large and wasting memory" %
+            (cur_swap, target_swap_size, SWAP_FILE))
+        os.remove(SWAP_FILE)
+    elif cur_swap >= target_swap_size - SWAP_RESERVED_SIZE:
         log("There's sufficient swap available (have %d, need %d)" %
             (cur_swap, target_swap_size))
         update_kernel_swap_offset(config.swapon, config.swapoff, SWAP_FILE, config.grub_update)


### PR DESCRIPTION


Description of changes:
This Pull request adds a logic of deleting and recreating the swap file, if the current swap is larger than the needed size. 
This will help wasting extra memory in storage and make it available to the user when modifying instances from larger to smaller type. 

Testing: Tested the change internally inside an instance by modifying the file.
