### PR TITLE
Update /sys/power/resume_offset and /sys/power/resume only if present

### DIFF
--- a/agent/hibinit-agent
+++ b/agent/hibinit-agent
@@ -133,13 +133,17 @@ def patch_grub_config(swap_device, offset):
     # Some of grubby versions need a restart after changing in kernel parameters
     # echo offset and swap device helps the customer to use the agent immediately
     # after rpm installation. 
-    echoResumeDeviceCmd = "echo {swap_device} > /sys/power/resume"
-    echoResumeDeviceCmd = echoResumeDeviceCmd.format(swap_device=swap_device)
-    echoResumeOffsetCmd = "echo {offset} > /sys/power/resume_offset"
-    echoResumeOffsetCmd = echoResumeOffsetCmd.format(offset=offset)
+    if os.path.exists("sys/power/resume"):
+       echoResumeDeviceCmd = "echo {swap_device} > /sys/power/resume"
+       echoResumeDeviceCmd = echoResumeDeviceCmd.format(swap_device=swap_device)
+       log("sys/power/resume exist and would be updated")
+       check_output(echoResumeDeviceCmd, shell=True)
 
-    check_output(echoResumeDeviceCmd, shell=True)
-    check_output(echoResumeOffsetCmd, shell=True)
+    if os.path.exists("/sys/power/resume_offset"):
+       echoResumeOffsetCmd = "echo {offset} > /sys/power/resume_offset"
+       echoResumeOffsetCmd = echoResumeOffsetCmd.format(offset=offset)
+       log("sys/power/resume_offset exist and would be updated")
+       check_output(echoResumeOffsetCmd, shell=True)
     log("GRUB configuration is updated")
 
 


### PR DESCRIPTION
Older kernel prior to `v4.7` do not contain the file /sys/power/resume_offset  and trying to update this results in error. This change make sure that the file exists before trying to update the file. 
This change was introduced via pull request https://github.com/aws/amazon-ec2-hibinit-agent/pull/17  but was recently included in al2 releases( 09/06/2023)

The al2 releases with older kernel is resulting in hibernation failure. 


Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
