### PR TITLE
hibinit-agent: Change message when removing SWAP

### DIFF
--- a/agent/hibinit-agent
+++ b/agent/hibinit-agent
@@ -473,7 +473,7 @@ def main():
 
     bi = None
     if cur_swap > target_swap_size - SWAP_RESERVED_SIZE + MAX_SWAP_SIZE_OFFSET_ALLOWED:
-        log("Swap already exists! (have %d, need %d), deleting existing swap file %s since current swap is sufficiently large and wasting memory" %
+        log("Swap already exists! (have %d, need %d), deleting existing swap file %s since current swap is sufficiently large and wasting disk space" %
             (cur_swap, target_swap_size, SWAP_FILE))
         os.remove(SWAP_FILE)
     elif cur_swap >= target_swap_size - SWAP_RESERVED_SIZE:


### PR DESCRIPTION
Just a small change to wording.

Change message from "wasting memory" to "wasting disk space" so it is not confused with a RAM optimization.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.