### PR TITLE
hibinit-agent: use non-generic swap name

### DIFF
--- a/agent/hibinit-agent
+++ b/agent/hibinit-agent
@@ -30,7 +30,7 @@ except:
 #space reserved for swap headers
 SWAP_RESERVED_SIZE = 16384
 log_to_syslog = True
-SWAP_FILE = '/swap'
+SWAP_FILE = '/swap-hibinit'
 
 DEFAULT_STATE_DIR = '/var/lib/hibinit-agent'
 HIB_ENABLED_FILE = "hibernation-enabled"


### PR DESCRIPTION
I'd like to open this PR to suggest using a non-generic SWAP name.

The benefit here is that the user may want SWAP to be a certain size, and having this utility change it automatically could be not what the user is expecting.

A note on packaging, is that if this change is accepted, the upgrade to this version should remove/resize the old /swap file in the maintainer scripts, and ensure the new swap file is created.