### PR TITLE
Critical termination protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 The Amazon Linux hibernation agent.
 
 The purpose of this agent is to create a setup for an instance to support hibernation feature. 
-The setup is created only on supported instance types. This agent does several things:
+The setup is created only on supported instance types. 
 
-1. Upon startup it checks for sufficient swap space to allow hibernate and fails
-   if it's present but there's not enough of it.
-2. If there's no swap space, it launches a background thread to create it and touch 
-   all of its blocks to make sure that EBS volumes are pre-warmed if configured.This is configurable.
+This agent does several things upon startup:
+1. It checks for sufficient swap space to allow hibernation and fails if not enough space
+2. If there's no swap file or the existing swap file isn't of a sufficient size,
+     it creates it and launches a background thread to touch all of its blocks
+     and makes sure that EBS volumes are pre-warmed.
 3. It updates the offset of the swap file in the kernel using SNAPSHOT_SET_SWAP_AREA ioctl.
 4. It updates the resume offset and resume device in grub file.
 

--- a/agent/hibinit-agent
+++ b/agent/hibinit-agent
@@ -1,10 +1,11 @@
 #!/usr/libexec/platform-python
-# AWS EC2 HibInit Agent. This agent does several things:
-# 1. Upon startup it checks for sufficient swap space to allow hibernate and fails
-#    if it's present but there's not enough of it.
-# 2. If there's no swap space, it creates it and launches a background thread to
-#    touch all of its blocks to make sure that EBS volumes are pre-warmed.
+# AWS EC2 HibInit Agent. This agent does several things upon startup:
+# 1. It checks for sufficient swap space to allow hibernation and fails if not enough space
+# 2. If there's no swap file or the existing swap file isn't of a sufficient size,
+#      it creates it and launches a background thread to touch all of its blocks
+#      and makes sure that EBS volumes are pre-warmed.
 # 3. It updates the offset of the swap file in the kernel using SNAPSHOT_SET_SWAP_AREA ioctl.
+# 4. It updates the resume offset and resume device in grub file.
 #
 # This file is compatible both with Python 2 and Python 3
 import argparse
@@ -21,13 +22,12 @@ import requests
 import signal
 from subprocess import check_call, check_output
 
-
 try:
     from ConfigParser import ConfigParser, NoSectionError, NoOptionError
 except:
     from configparser import ConfigParser, NoSectionError, NoOptionError
 
-#space reserved for swap headers
+# Space reserved for swap headers
 SWAP_RESERVED_SIZE = 16384
 log_to_syslog = True
 SWAP_FILE = '/swap'
@@ -39,23 +39,42 @@ IMDS_API_TOKEN_PATH = 'latest/api/token'
 IMDS_SPOT_ACTION_PATH = 'latest/meta-data/hibernation/configured'
 MAX_SWAP_SIZE_OFFSET_ALLOWED = 100 * 1024
 
+# Sigterm_handler Behaviour Modifiers
+CRITICAL_PROCESS_IN_PROGRESS = False
+SHUTDOWN_REQUESTED = False
+
+
 def log(message):
     if log_to_syslog:
         syslog.syslog(message)
 
-def sigterm_handler(signal, frame):
-    #save the state here or do whatever you want
-    log('Process killed cleaning up!')
-    cmd = "swapon -s | cut -f1,1 | grep -w {name}"
-    cmd = cmd.format(name=SWAP_FILE)
-    swapoff = "swapoff {filename}"
-    cmd = check_output(cmd, shell=True)
-    if cmd.strip() == SWAP_FILE:
-        print("Turning off swap for cleanup")
-        swapoff = swapoff.format(filename=SWAP_FILE)
-        check_call(swapoff, shell=True)
-    if os.path.isfile(SWAP_FILE) and os.access(SWAP_FILE, os.R_OK):
-        os.remove(SWAP_FILE)
+
+def sigterm_handler(signum, frame):
+    if CRITICAL_PROCESS_IN_PROGRESS:
+        global SHUTDOWN_REQUESTED
+        SHUTDOWN_REQUESTED = True
+    else:
+        cmd = "swapon -s | cut -f1,1 | grep -w {name}"
+        cmd = cmd.format(name=SWAP_FILE)
+        swapoff = "swapoff {filename}"
+        cmd = check_output(cmd, shell=True)
+        if cmd.strip() == SWAP_FILE:
+            swapoff = swapoff.format(filename=SWAP_FILE)
+            check_call(swapoff, shell=True)
+        if os.path.isfile(SWAP_FILE) and os.access(SWAP_FILE, os.R_OK):
+            os.remove(SWAP_FILE)
+        exit(0)
+
+
+def begin_critical_process():
+    global CRITICAL_PROCESS_IN_PROGRESS
+    CRITICAL_PROCESS_IN_PROGRESS = True
+
+
+def end_critical_process():
+    global CRITICAL_PROCESS_IN_PROGRESS
+    CRITICAL_PROCESS_IN_PROGRESS = False
+    if SHUTDOWN_REQUESTED:
         exit(0)
 
 
@@ -91,24 +110,18 @@ def get_rootfs_size():
     return math.ceil(float(stat.f_bsize * stat.f_blocks)/(1024*1024*1024))
 
 
-#This is only for grub2
+# This is only for grub2
 def find_grub_mount():
-    confFile = ''
-    pathList = []
-    pathList.append("/etc/grub2-efi.cfg")
-    pathList.append("/boot/grub2/grub.cfg")
-    pathList.append("/boot/grub2-efi/grub.cfg")
-    pathList.append("/etc/grub2.cfg")
-    pathList.append("NULL")
-    cmd = 'stat -L -c %m'
-    for ln in pathList:
-        if ln!='NULL' and os.path.isfile(ln) and os.access(ln, os.R_OK):
-            break
-    if ln=='NULL':
-        return None
-    cmd = cmd + ' ' + ln
-    mount = check_output(cmd, shell=True, universal_newlines=True)
-    return mount.strip()
+    path_list = ['/etc/grub2-efi.cfg',
+                 '/boot/grub2/grub.cfg',
+                 '/boot/grub2-efi/grub.cfg',
+                 '/etc/grub2.cfg']
+    for ln in path_list:
+        if os.path.isfile(ln) and os.access(ln, os.R_OK):
+            cmd = 'stat -L -c %m ' + ln
+            mount = check_output(cmd, shell=True, universal_newlines=True)
+            return mount.strip()
+    return None
 
 
 def patch_grub_config(swap_device, offset):
@@ -142,6 +155,7 @@ def patch_grub_config(swap_device, offset):
        log("sys/power/resume_offset exist and would be updated")
        check_output(echoResumeOffsetCmd, shell=True)
     log("GRUB configuration is updated")
+
 
 def update_kernel_swap_offset(swapon, swapoff, filename, grub_update, btrfs_enabled):
     swapon = swapon.format(swapfile=filename)
@@ -177,7 +191,8 @@ def update_kernel_swap_offset(swapon, swapoff, filename, grub_update, btrfs_enab
     swapoff = swapoff.format(swapfile=filename)
     log("Running: %s" % swapoff)
     check_call(swapoff, shell=True)
-    check_call("dracut -a resume -f", shell=True)
+    check_call("trap '' HUP INT QUIT TERM && dracut -a resume -f", shell=True)
+
 
 def find_device_for_file(filename):
     # Find the mount point for the swap file ('df -P /swap')
@@ -275,14 +290,17 @@ class SwapInitializer(object):
 
 
 class BackgroundInitializerRunner(object):
-    def __init__(self, swapper, update_grub, btrfs_enabled):
+    def __init__(self, swapper, swapon, swapoff, filename, update_grub, btrfs_enabled):
         self.swapper = swapper
         self.thread = None
         self.error = None
+        self.swapon = swapon
+        self.swapoff = swapoff
+        self.filename = filename
         self.update_grub = update_grub
         self.btrfs_enabled = btrfs_enabled
 
-    def start_init(self):
+    def init_background_process(self):
         try:
             pid = os.fork()
             if pid > 0:
@@ -297,10 +315,16 @@ class BackgroundInitializerRunner(object):
         os.setsid()
         os.umask(0o22)
 
-    def do_async_init(self):
+        # Configures to handle kills gracefully
+        signal.signal(signal.SIGTERM, sigterm_handler)
+
+    def init_hibernate_setup(self):
         try:
-            self.swapper.init_swap()
-            update_kernel_swap_offset(self.swapper.swapon, self.swapper.swapoff, self.swapper.filename, self.update_grub, self.btrfs_enabled)
+            if self.swapper is not None:
+                self.swapper.init_swap()
+            begin_critical_process()
+            update_kernel_swap_offset(self.swapon, self.swapoff, self.filename, self.update_grub, self.btrfs_enabled)
+            end_critical_process()
         except Exception as ex:
             log("Failed to initialize swap when using async, reason: %s" % str(ex))
             self.error = ex
@@ -369,7 +393,6 @@ class Config(object):
         if self.state_dir is None:
             self.state_dir = DEFAULT_STATE_DIR
 
-
     def merge(self, cf_value, arg_value, def_val):
         if arg_value is not None:
             return arg_value
@@ -391,6 +414,7 @@ class Config(object):
     def __str__(self):
         return str(self.__dict__)
 
+
 def get_imds_token(seconds=21600):
     """ Get a token to access instance metadata. """
     log("Requesting new IMDSv2 token.")
@@ -403,10 +427,12 @@ def get_imds_token(seconds=21600):
 
     return response.text
 
+
 def create_state_dir(state_dir):
-    """ Create agent run dir if it doesn't exists."""
+    """ Create agent run dir if it doesn't exist."""
     if not os.path.isdir(state_dir):
         os.makedirs(state_dir)
+
 
 def hibernation_enabled(state_dir):
     """Returns a boolean indicating whether hibernation is enabled or not.
@@ -435,10 +461,11 @@ def hibernation_enabled(state_dir):
 
     log("Hibernation Configured Flag found")
     os.mknod(hib_sem_file)
-
     return True
 
+
 def main():
+
     # Parse arguments
     parser = argparse.ArgumentParser(description="An EC2 background process that creates a setup for instance hibernation "
                                                  "at instance launch and also registers ACPI sleep event/actions")
@@ -487,17 +514,19 @@ def main():
     if os.path.isfile(SWAP_FILE) and os.access(SWAP_FILE, os.R_OK):
         cur_swap = os.path.getsize(SWAP_FILE)
 
-    bi = None
+    bi = BackgroundInitializerRunner(None, config.swapon, config.swapoff, SWAP_FILE, config.grub_update, config.btrfs_enabled)
     if cur_swap > target_swap_size - SWAP_RESERVED_SIZE + MAX_SWAP_SIZE_OFFSET_ALLOWED:
-        log("Swap already exists! (have %d, need %d), deleting existing swap file %s since current swap is sufficiently large and wasting disk space" %
+        log("Swap already exists! (have %d, need %d), deleting existing swap file %s since current swap is "
+              "sufficiently large and wasting disk space" %
             (cur_swap, target_swap_size, SWAP_FILE))
         os.remove(SWAP_FILE)
     elif cur_swap >= target_swap_size - SWAP_RESERVED_SIZE:
         log("There's sufficient swap available (have %d, need %d)" %
             (cur_swap, target_swap_size))
-        update_kernel_swap_offset(config.swapon, config.swapoff, SWAP_FILE, config.grub_update, config.btrfs_enabled)
+        bi.init_background_process()
+        bi.init_hibernate_setup()
         exit()
-    #validate if instance was launched from pre-created image and swap size>=total RAM, if not re-create the swap 
+    # Validate if instance was launched from pre-created image and swap size>=total RAM, if not re-create the swap
     elif cur_swap > 0 and (cur_swap < target_swap_size - SWAP_RESERVED_SIZE):
         log("Swap already exists! (have %d, need %d), deleting existing swap file %s" %
             (cur_swap, target_swap_size, SWAP_FILE))
@@ -508,7 +537,7 @@ def main():
     swap_dev = os.path.dirname(SWAP_FILE)
     st = os.statvfs(swap_dev)
     free_bytes = st.f_bavail * st.f_frsize
-    #rounding off to swap_size+10mb for swap headers
+    # Rounding off to swap_size+10mb for swap headers
     free_space_needed = target_swap_size + 10 * 1024 * 1024
     if free_space_needed >= free_bytes:
         log("There's not enough space (%d present, %d needed) on the device: %s" % (
@@ -519,17 +548,11 @@ def main():
 
     sw = SwapInitializer(SWAP_FILE, target_swap_size, config.touch_swap, config.btrfs_enabled,
                              config.mkswap, config.swapoff, config.swapon)
-    bi = BackgroundInitializerRunner(sw, config.grub_update, config.btrfs_enabled)
-
-    signal.signal(signal.SIGTERM, sigterm_handler)
-    signal.signal(signal.SIGHUP, sigterm_handler)
-    signal.signal(signal.SIGINT, sigterm_handler)
-    signal.signal(signal.SIGQUIT, sigterm_handler)
-    if bi:
-        bi.start_init()
+    bi.swapper = sw
+    bi.init_background_process()
 
     log("kicking child process to initiate the setup")
-    bi.do_async_init()
+    bi.init_hibernate_setup()
 
 if __name__ == '__main__':
     main()

--- a/ec2-hibinit-agent.spec
+++ b/ec2-hibinit-agent.spec
@@ -1,10 +1,10 @@
 Name:           ec2-hibinit-agent
-Version:        1.0.2
-Release:        7%{?dist}
+Version:        1.0.8
+Release:        8%{?dist}
 Summary:        Hibernation setup utility for AWS EC2
 
 Group:          System Environment/Daemons
-License:         Apache 2.0
+License:        Apache 2.0
 Source0:        ec2-hibinit-agent-%{version}.tar.gz
 BuildArch:      noarch
 BuildRequires:  python2 python2-devel systemd acpid
@@ -23,7 +23,7 @@ An EC2 agent that creates a setup for instance hibernation
 %install
 %{__python2} setup.py install --prefix=usr -O1 --skip-build --root $RPM_BUILD_ROOT
 mkdir -p "%{buildroot}%{_unitdir}"
-mkdir -p %{buildroot}%{_sysconfdir}/acpi/events 
+mkdir -p %{buildroot}%{_sysconfdir}/acpi/events
 mkdir -p %{buildroot}%{_sysconfdir}/acpi/actions
 mkdir -p %{buildroot}%{_localstatedir}/lib/hibinit-agent
 install -p -m 644 "%{_builddir}/%{name}-%{version}/hibinit-agent.service" %{buildroot}%{_unitdir}
@@ -58,6 +58,33 @@ rm -rf $RPM_BUILD_ROOT
 %systemd_postun_with_restart hibinit-agent.service
 
 %changelog
+* Thu Dec 27 2023 Jeff Kim <kjeffsh@amazon.com> - 1.0.7-8
+- Added better termination behaviour with a stop timeout of 2 minutes
+
+* Wed Oct 18 2023 Jeff Kim <kjeffsh@amazon.com> - 1.0.6-7
+- Changed message when removing swap file
+- Adding btrfs-enabled to set No_COW and get offset using btrfs
+
+* Thu Sep 28 2023 Deborshi Saha <ddebs@amazon.com> - 1.0.5-6
+- Add initial Amazon Linux 2022 support
+- Add pm-utils for required package
+- Recreate the swap file if the current size is sufficiently larger
+- Update /sys/power/resume_offset and /sys/power/resume only if present
+
+* Mon May 24 2021 Mohamed Aboubakr <mabouba@amazon.com> - 1.0.4-5
+- Adding spec file for suse Linux
+- swapon with max priority when hibernating
+
+* Mon May 24 2021 Mohamed Aboubakr <mabouba@amazon.com> - 1.0.3-4
+- grub2 mkconfig before grub configuration update
+- Update /sys/power after grub configuration update
+- Adding dracut to recreate initramfs after config update
+
+* Thu Jan 14 2021 Mohamed Aboubakr <mabouba@amazon.com> - 1.0.2-3
+- Add python3 support
+- Support Redhat 8 by adding spec file for redhat and more configuration for acpid
+- Remove config no replace for files that do not exist in etc directory
+
 * Fri Jan 24 2020 Frederick Lefebvre <fredlef@amazon.com> - 1.0.1-2
 - Restart the hibinit-agent service on upgrade
 
@@ -73,3 +100,4 @@ rm -rf $RPM_BUILD_ROOT
 
 * Wed Oct 31 2018 Anchal Agarwal <anchalag@amazon.com> - 1.0.0-1
 - Initial build
+

--- a/hibinit-agent.service
+++ b/hibinit-agent.service
@@ -13,14 +13,18 @@
 
 [Unit]
 Description=Initial hibernation setup job
-DefaultDependencies=no
 After=cloud-config.service
+Wants=acpid.service
 
 [Service]
 Type=forking
 ExecStart=/usr/bin/hibinit-agent -c /etc/hibinit-config.cfg
-ExecStartPost= /bin/systemctl restart acpid.service
-TimeoutSec=0
+TimeoutStartSec=0
+
+# Ensures a graceful shutdown on stop
+TimeoutStopSec=120
+KillMode=mixed
+KillSignal=SIGTERM
 
 # Output needs to appear in instance console output
 StandardOutput=journal+console


### PR DESCRIPTION
## Issue:

The hibinit-agent does not gracefully terminate on shutdown. 
As we have `DefaultDependencies=no` in `hibinit-agent.service`, our process may be abruptly killed during a critical process (e.g. dracut). 

This can lead to issues various issues on resume; At worse, the root fs may fail to mount correctly.

## Description of changes:

#### Hibinit-agent.service

Added a 2 minute timeout when the service is requested to stop. 
This should give our service ample time to complete any critical process in progress and exit gracefully.

#### Hibinit-agent

SIGTERM will now check if the global boolean `CRITICAL_PROCESS_IN_PROGRESS` is true. 
If so, the agent will not exit until said process is completed. (Indicated by another `SHUTDOWN_REQUESTED` global boolean)

If no critical process is running, we will attempt to terminate the agent after attempting to remove the swap file & ensuring it is not `swapon`.

These changes were both manually tested for each supported OS.
In addition, each passed our 99.9 percent success rate in batch end-to-end testing

| OS           | Manually Tested? | TotalRuns | RunsSucceeded | RunsFailed | Percentage |
|--------------|------------------|-----------|---------------|------------|------------|
| AL2          | Yes              |      10000 |          9999 |          1 |       99.99 |
| AL2023       | Yes              |      1000 |          1000 |          0 |        100 |
| Ubuntu Focal | Yes              |      1000 |          1000 |          0 |        100 |
| Ubuntu Jammy | Yes              |      1000 |          1000 |          0 |        100 |
| RHEL8        | Yes              |      1000 |          1000 |          0 |        100 |
| RHEL9        | Yes              |      1000 |          1000 |          0 |        100 |

----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
