### PR TITLE
Adding swapoff to acpid.sleep retry attempts

### DIFF
--- a/acpid.sleep.sh
+++ b/acpid.sleep.sh
@@ -30,6 +30,7 @@ case "$2" in
           hibernate
           if [ $failed == 'true' ];
           then
+            swapoff /swap
             sleep 2m
           else
            break


### PR DESCRIPTION
Issue #, if available:

In the edge case that the swap file is already mounted when hibernation is triggered, we should swap off before retrying.
Additionally, if `pm-hibernate` is to fail, we should swap off before retrying again.

Description of changes:

Adding swapoff to `acpid.sleep.sh`'s retry behaviour

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
