### PR TITLE
Updates for Ubuntu ARM - /dev/snapshot does not exist

### DIFF
--- a/agent/hibinit-agent
+++ b/agent/hibinit-agent
@@ -193,7 +193,7 @@ def update_kernel_swap_offset(config):
 
     print_to_sys_log("Setting swap device to %d with offset %d" % (dev, offset))
 
-    if not config.btrfs_enabled:
+    if not config.btrfs_enabled and os.path.exists("/dev/snapshot"):
         # Set the kernel swap offset, see https://www.kernel.org/doc/Documentation/power/userland-swsusp.txt
         # From linux/suspend_ioctls.h
         snapshot_set_swap_area = 0x400C330D


### PR DESCRIPTION
Confirm /dev/snapshot exists before updating resume parameters again. Parameters are already set via Grub config update.

Description of changes:

Needed for Ubuntu ARM Hibernation, where the /dev/snapshot does not exist. The agent already manually updates the resume parameters in line 190 by updating the GRUB file.
Tested on Ubuntu x86, where /dev/snapshot exists, and confirmed there is no behavior change. Tested on Ubuntu ARM, where /dev/snapshot does not exist, and the agent runs successfully and allows for successful hibernation.
Batch tested on with the agent change Ubuntu Jammy using internal Amazon tools (with %50 of memory allocated) and achieved a >99% success rate on hibernate/resumes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
