### PR TITLE
Fix swap allocation bug

### DIFF
--- a/agent/hibinit-agent
+++ b/agent/hibinit-agent
@@ -48,7 +48,6 @@ DEFAULT_SWAP_PERCENTAGE = 100
 # Sigterm_handler Behaviour Modifiers
 SHUTDOWN_REQUESTED = False
 
-
 def print_to_sys_log(message):
     if LOG_TO_SYSLOG:
         syslog.syslog(message)
@@ -217,7 +216,11 @@ def find_device_for_file(filename):
 
 class SwapInitializer(object):
     def __init__(self, config):
-        self.swap_size = config.swap_mb * KB * KB
+        self.swap_size = calc_target_swap_size(
+            ram_bytes=os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES'),
+            swap_percentage=config.swap_percentage,
+            swap_mb=config.swap_mb)
+
         self.config = config
         self.block_size = KB * KB  # 1 MiB
 
@@ -415,10 +418,16 @@ def hibernation_enabled(state_dir):
     os.mknod(hib_sem_file)
     return True
 
+def calc_target_swap_size(ram_bytes: int, swap_percentage: int, swap_mb: int) -> int: 
+    target_swap_size = swap_mb * KB * KB  # Converting to bytes
+    swap_percentage_size = ram_bytes * swap_percentage // 100
+    if swap_percentage_size > target_swap_size:
+        target_swap_size = int(swap_percentage_size)
+
+    return target_swap_size
 
 # Returns a tuple denoting (valid_to_init_hibernation: bool, new_swap_file_required: bool)
 def validate_system_requirements(config):
-    target_swap_size = config.swap_mb * KB * KB  # Converting to bytes
     # Validate if disk space>total RAM
     ram_bytes = os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES')
     if get_rootfs_size() <= (math.ceil(float(ram_bytes) / (KB * KB * KB))):
@@ -426,9 +435,8 @@ def validate_system_requirements(config):
             "Insufficient disk space. Cannot create setup for hibernation. Please allocate a larger root device")
         return False, False
 
-    swap_percentage_size = ram_bytes * config.swap_percentage // 100
-    if swap_percentage_size > target_swap_size:
-        target_swap_size = int(swap_percentage_size)
+    target_swap_size = calc_target_swap_size(ram_bytes, config.swap_percentage, config.swap_mb)
+   
     print_to_sys_log("Will check if swap is at least: %d megabytes" % (target_swap_size // (KB * KB)))
 
     # Validate if swap file exists

--- a/agent/hibinit-agent
+++ b/agent/hibinit-agent
@@ -418,7 +418,7 @@ def hibernation_enabled(state_dir):
     os.mknod(hib_sem_file)
     return True
 
-def calc_target_swap_size(ram_bytes: int, swap_percentage: int, swap_mb: int) -> int: 
+def calc_target_swap_size(ram_bytes, swap_percentage, swap_mb): 
     target_swap_size = swap_mb * KB * KB  # Converting to bytes
     swap_percentage_size = ram_bytes * swap_percentage // 100
     if swap_percentage_size > target_swap_size:

--- a/ec2-hibinit-agent.spec
+++ b/ec2-hibinit-agent.spec
@@ -1,5 +1,5 @@
 Name:           ec2-hibinit-agent
-Version:        1.0.9
+Version:        1.0.10
 Release:        1%{?dist}
 Summary:        Hibernation setup utility for AWS EC2
 

--- a/ec2-hibinit-agent.spec
+++ b/ec2-hibinit-agent.spec
@@ -1,5 +1,5 @@
 Name:           ec2-hibinit-agent
-Version:        1.0.10
+Version:        1.0.9-1
 Release:        1%{?dist}
 Summary:        Hibernation setup utility for AWS EC2
 
@@ -61,6 +61,9 @@ rm -rf $RPM_BUILD_ROOT
 %systemd_postun_with_restart hibinit-agent.service
 
 %changelog
+* Thu Sep 19 2024 Jarred Desrosiers <jarredtd@amazon.com> - 1.0.9-1
+- Add check for swap allocation to use bigger of configuration options percentage-of-ram and target-size-mb.
+
 * Thu May 16 2024 Seth Carolan <secarola@amazon.com> - 1.0.9
 - Confirm /dev/snapshot exists before updating resume parameters again. Parameters are already set via Grub config update.
 

--- a/ec2-hibinit-agent.spec
+++ b/ec2-hibinit-agent.spec
@@ -1,5 +1,5 @@
 Name:           ec2-hibinit-agent
-Version:        1.0.9-1
+Version:        1.0.9
 Release:        1%{?dist}
 Summary:        Hibernation setup utility for AWS EC2
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open("README.md", "r") as fp:
     hib_long_description = fp.read()
 
 setup(name="ec2-hibinit-agent",
-      version='1.0.9',
+      version='1.0.9-1',
       author="Anchal Agarwal",
       author_email="anchalag@amazon.com",
       tests_require=["pytest"],	

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open("README.md", "r") as fp:
     hib_long_description = fp.read()
 
 setup(name="ec2-hibinit-agent",
-      version='1.0.9-1',
+      version='1.0.9',
       author="Anchal Agarwal",
       author_email="anchalag@amazon.com",
       tests_require=["pytest"],	


### PR DESCRIPTION
## Summary

`SwapInitializer` was not using the greater of the two configuration options: `percentage-of-ram` and `target-size-mb`, but instead just `target-size-mb`. Logic to determine which is greater and to use the greater were added to the `SwapInitalizer`.

## Testing

Hibernation confirmed working on AL2023, Rocky8, Ubuntu, etc with proper allocation for swap based on the greater of the two configuration options.

```
Sep 18 08:54:12 ip-172-31-45-67 /hibinit-agent[23392]: Will check if swap is at least: 7536 megabytes
Sep 18 08:54:12 ip-172-31-45-67 /hibinit-agent[23392]: There's enough space (27805196288 present, 7912640512 needed) for the swap file on the device: /
Sep 18 08:54:12 ip-172-31-45-67 /hibinit-agent[23392]: Allocating 7902154752 bytes in /swap
Sep 18 08:54:12 ip-172-31-45-67 /hibinit-agent[23392]: Opening /swap for direct IO
Sep 18 08:54:12 ip-172-31-45-67 /hibinit-agent[23392]: Touching all blocks in /swap
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.