### PR TITLE
fix(rhel): Swapon with maximum priority before hibernation

### DIFF
--- a/packaging/rhel/acpid.sleep.sh
+++ b/packaging/rhel/acpid.sleep.sh
@@ -3,11 +3,14 @@
 PATH=/sbin:/bin:/usr/bin
 failed='false'
 
+# Hibernation selects the swapfile with highest priority. Since there may be
+# other swapfiles configured, ensure /swap is selected as hibernation
+# target by setting to maximum priority.
+swap_priority=32767
+
 hibernate()
 {
-        swapon /swap
-        systemctl hibernate
-
+        swapon --priority=$swap_priority /swap && systemctl hibernate
         if [ $? -ne 0 ]
         then
             logger "Hibernation failed, Sleeping 2 mins before retry"
@@ -15,6 +18,7 @@ hibernate()
         else
             failed='false'
         fi
+        swapoff /swap
 }
 
 case "$2" in
@@ -26,6 +30,7 @@ case "$2" in
           hibernate
           if [ $failed == 'true' ];
           then
+            swapoff /swap
             sleep 2m
           else
            break


### PR DESCRIPTION
Issue #, if available:

Downstream, EPEL Package Bug: https://bugzilla.redhat.com/show_bug.cgi?id=2322884

Description of changes:

Apply swapon high priority related changes from /acpid.sleep.sh to /packaging/rhel/acpid.sleep.sh

Refs: https://github.com/aws/amazon-ec2-hibinit-agent/commit/a2303d269610a6e7415c5045766da605eaa7e30f

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
