### PR TITLE
Use systemctl hibernate instead of pm-hibernate

### DIFF
--- a/acpid.sleep.sh
+++ b/acpid.sleep.sh
@@ -10,7 +10,7 @@ swap_priority=32767
 
 hibernate()
 {
-        swapon --priority=$swap_priority /swap && /usr/sbin/pm-hibernate
+        swapon --priority=$swap_priority /swap && systemctl hibernate
         if [ $? -ne 0 ]
         then
             logger "Hibernation failed, Sleeping 2 mins before retry"


### PR DESCRIPTION
"systemctl hibernate" is the default on AL2023[0] and Ubuntu[1] so make it the default upstream so patching the downstream packages is no longer required.

[0] ec2-hibinit-agent-1.0.8-0.amzn2023.src.rpm does use "systemctl hibernate" in acpid.sleep.sh
[1] check patches applied to the debian package from https://launchpad.net/ubuntu/+source/ec2-hibinit-agent

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
