### PR TITLE
fix: Remove resume-time swapoff and add defensive guards to sleep scripts

### DIFF
--- a/acpid.sleep.sh
+++ b/acpid.sleep.sh
@@ -24,27 +24,32 @@ should_hibernate() {
     local now=$(date +%s)
 
     if [ -f "$RESUMED_AT" ]; then
-        local resumed=$(cat "$RESUMED_AT")
-        local since_resume=$((now - resumed))
+        local resumed=$(cat "$RESUMED_AT" 2>/dev/null)
+        if [ -n "$resumed" ] && [ "$resumed" -eq "$resumed" ] 2>/dev/null; then
+            local since_resume=$((now - resumed))
 
-        if [ $since_resume -lt $STALE_THRESHOLD ]; then
-            log notice "Resumed ${since_resume}s ago, skipping"
-            return 1
+            if [ $since_resume -lt $STALE_THRESHOLD ]; then
+                log notice "Resumed ${since_resume}s ago, skipping"
+                return 1
+            fi
         fi
 
         return 0
     fi
 
     if [ -f "$HIBERNATED_AT" ]; then
-        local hibernated=$(cat "$HIBERNATED_AT")
-        local since_hibernate=$((now - hibernated))
+        local hibernated=$(cat "$HIBERNATED_AT" 2>/dev/null)
+        if [ -n "$hibernated" ] && [ "$hibernated" -eq "$hibernated" ] 2>/dev/null; then
+            local since_hibernate=$((now - hibernated))
 
-        if [ $since_hibernate -lt $STALE_THRESHOLD ]; then
-            log notice "Hibernation started ${since_hibernate}s ago, skipping"
-            return 1
+            if [ $since_hibernate -lt $STALE_THRESHOLD ]; then
+                log notice "Hibernation started ${since_hibernate}s ago, skipping"
+                return 1
+            fi
+
+            log notice "Stale hibernated_at (${since_hibernate}s old), clearing"
         fi
 
-        log notice "Stale hibernated_at (${since_hibernate}s old), clearing"
         rm -f "$HIBERNATED_AT"
         return 0
     fi
@@ -56,19 +61,24 @@ do_hibernate() {
     local event="$1"
 
     for i in 1 2 3; do
-        log notice "Attempt $i/3: Enabling swap"
-
-        if ! swapon --priority=$swap_priority /swap; then
-            log err "Attempt $i/3: Failed to enable swap, retrying in 10s"
-            sleep 10
-            continue
+        # Swap must be on to hibernate. Only enable it if /swap is not
+        # already active so a pre-existing swap is left untouched.
+        if swapon --show | grep -q '/swap'; then
+            log notice "Attempt $i/3: /swap already active"
+        else
+            log notice "Attempt $i/3: Enabling swap"
+            if ! swapon --priority=$swap_priority /swap; then
+                log err "Attempt $i/3: Failed to enable swap, retrying in 10s"
+                sleep 10
+                continue
+            fi
         fi
 
         log notice "Attempt $i/3: Swap enabled, initiating hibernation"
         sleep 1
 
         if systemctl hibernate; then
-            log notice "Hibernate initiated"
+            log notice "Hibernation initiated"
             return 0
         else
             log err "Attempt $i/3: Hibernation initiation failed, disabling swap, retrying in 10s"

--- a/sleep-handler.sh
+++ b/sleep-handler.sh
@@ -1,9 +1,17 @@
 #!/bin/bash
 
-# This is called before hibernating or after resuming, as follows:
-# $0=/usr/lib/systemd/system-sleep/sleepyhead, $1=pre, $2=suspend
-# ...and when the lid is opened, as follows:
-# $0=/usr/lib/systemd/system-sleep/sleepyhead, $1=post, $2=suspend
+# Runs on resume from hibernation via the systemd system-sleep hook:
+#   $1=post $2=hibernate
+#
+# Records the resume time so acpid.sleep.sh's should_hibernate() can debounce a
+# spurious sleep-button event that arrives shortly after a resume.
+#
+# We intentionally do NOT swapoff /swap here. After a successful resume the
+# kernel has already invalidated the hibernation image (the swap signature is
+# reset during resume), so the swap area is just ordinary swap again and does
+# not need tearing down. swapoff would have to page the entire image back into
+# RAM synchronously; on a memory-heavy host that cannot fit, swapoff blocks in
+# uninterruptible (D) state and freezes the instance.
 
 HIBERNATE_STATE_DIR=/var/run/hibernate
 RESUMED_AT="$HIBERNATE_STATE_DIR/resumed_at"
@@ -16,16 +24,6 @@ log() {
 if [ "$1" = "post" ]; then
     resumed_time=$(date +%s)
     log "Resumed at $resumed_time"
+    mkdir -p "$HIBERNATE_STATE_DIR"
     echo "$resumed_time" > "$RESUMED_AT"
-
-    if swapon --show | grep -q '/swap'; then
-        log "Disabling /swap post resume"
-        if swapoff /swap; then
-            log "/swap disabled successfully"
-        else
-            log "ERROR: Failed to disable /swap"
-        fi
-    else
-        log "/swap not active, skipping swapoff"
-    fi
 fi


### PR DESCRIPTION
### Summary

These fixes address two issues:

1. **D-state freeze on resume** - `sleep-handler.sh` previously called `swapoff /swap` after resume. On memory-heavy hosts where the swap image couldn't be paged back into RAM, `swapoff` would block in uninterruptible (D) state, freezing the instance. The kernel already invalidates the hibernation image during resume, so the swap area is safe to leave active.

2. **Possible hibernate failures from corrupt state files** - `acpid.sleep.sh` now validates that timestamp files contain numeric data before doing arithmetic. Also checks if `/swap` is already active before calling `swapon`, avoiding unnecessary failures when swap was never torn down.

### Changes

- `sleep-handler.sh` — Remove swapoff logic entirely; only record `resumed_at` timestamp for debounce
- `acpid.sleep.sh` — Add `2>/dev/null` and numeric validation on state file reads; skip `swapon` if `/swap` is already active